### PR TITLE
Fixes for building libGimbal with symbol exporting (for shared libraries) enabled.

### DIFF
--- a/lib/api/gimbal/core/gimbal_module.h
+++ b/lib/api/gimbal/core/gimbal_module.h
@@ -144,7 +144,10 @@ GblType     GblModule_registerType  (GBL_SELF,
 
 GblType     GblModule_typeFromName  (GBL_CSELF, const char* pName)  GBL_NOEXCEPT;
 GblType     GblModule_typeFromIndex (GBL_CSELF, size_t      index)  GBL_NOEXCEPT;
-size_t      GblModule_typeCount     (GBL_CSELF)                     GBL_NOEXCEPT;
+
+// Fix for Windows: "Redefinition with different linkage"
+// Added GBL_EXPORT here and removed from implementation in gimbal_module.c
+GBL_EXPORT size_t GblModule_typeCount     (GBL_CSELF)               GBL_NOEXCEPT;
 
 GBL_DECLS_END
 

--- a/lib/source/core/gimbal_module.c
+++ b/lib/source/core/gimbal_module.c
@@ -311,7 +311,9 @@ GBL_EXPORT GblRefCount GblModule_unref(GblModule* pSelf) {
     return GBL_UNREF(pSelf);
 }
 
-GBL_EXPORT size_t GblModule_typeCount(const GblModule* pSelf) {
+// Fix for Windows: "Redefinition with different linkage"
+// Removed GBL_EXPORT from here and added to declaration in gimbal_module.h
+size_t GblModule_typeCount(const GblModule* pSelf) {
     GBL_UNUSED(pSelf);
     return 0;
 }

--- a/lib/source/meta/classes/gimbal_class.c
+++ b/lib/source/meta/classes/gimbal_class.c
@@ -339,7 +339,9 @@ GBL_EXPORT GblClass* (GblClass_createFloating)(GblType type,
     return pClass;
 }
 
-static GBL_EXPORT GBL_RESULT GblClass_destruct_(GblClass* pClass) {
+// Fix for Windows: "Function must have external linkage to be exported"
+// Removed GBL_EXPORT from this static function.
+static GBL_RESULT GblClass_destruct_(GblClass* pClass) {
     GblMetaClass* pMeta = GBL_META_CLASS_(GBL_CLASS_TYPEOF(pClass));
     GBL_CTX_BEGIN(pCtx_);
     GBL_CTX_DEBUG("Destroying %s class!", GblType_name(GBL_TYPE_(pMeta)));

--- a/lib/source/meta/signals/gimbal_signal.c
+++ b/lib/source/meta/signals/gimbal_signal.c
@@ -582,7 +582,9 @@ GBL_EXPORT size_t  GblSignal_disconnect(GblInstance* pEmitter,
     return GblSignal_disconnect_(pEmitter, pSignalName, pReceiver, pClosure, NULL, NULL);
 }
 
-GBL_EXPORT GBL_RESULT GblSignal_removeInstance_(GblInstance* pInstance) {
+// Fix for Windows: "Redefinition with different linkage".
+// GBL_EXPORT moved to declaration in gimbal_type_.h
+GBL_RESULT GblSignal_removeInstance_(GblInstance* pInstance) {
     GBL_CTX_BEGIN(GblHashSet_context(&instanceConnectionTableSet_));
 
     InstanceConnectionTable_* pTable = InstanceConnectionTable_find_(pInstance);
@@ -768,7 +770,9 @@ GBL_EXPORT GblInstance* GblSignal_receiver(void) {
     return pActiveConnection_? pActiveConnection_->pReceiver : NULL;
 }
 
-GBL_EXPORT GBL_RESULT GblSignal_init_(GblContext* pCtx) {
+// Fix for Windows: "Redefinition with different linkage".
+// GBL_EXPORT moved to declaration in gimbal_type_.h
+GBL_RESULT GblSignal_init_(GblContext* pCtx) {
     GBL_CTX_BEGIN(pCtx);
     GBL_CTX_VERIFY_CALL(GblHashSet_construct(&signalSet_,
                                              sizeof(Signal_*),
@@ -795,7 +799,9 @@ GBL_EXPORT GBL_RESULT GblSignal_init_(GblContext* pCtx) {
     GBL_CTX_END();
 }
 
-GBL_EXPORT GBL_RESULT GblSignal_final_(GblContext* pCtx) {
+// Fix for Windows: "Redefinition with different linkage".
+// GBL_EXPORT moved to declaration in gimbal_type_.h
+GBL_RESULT GblSignal_final_(GblContext* pCtx) {
     GBL_CTX_BEGIN(pCtx);
     GBL_CTX_CALL(GblHashSet_destruct(&signalSet_));
     GBL_CTX_CALL(GblHashSet_destruct(&instanceConnectionTableSet_));

--- a/lib/source/meta/types/gimbal_type_.h
+++ b/lib/source/meta/types/gimbal_type_.h
@@ -100,9 +100,11 @@ extern GBL_RESULT    GblModule_final_                  (void);
 extern GBL_RESULT    GblProperty_init_                 (GblContext* pCtx);
 extern GBL_RESULT    GblProperty_final_                (GblContext* pCtx);
 
-extern GBL_RESULT    GblSignal_init_                   (GblContext* pCtx);
-extern GBL_RESULT    GblSignal_final_                  (GblContext* pCtx);
-extern GBL_RESULT    GblSignal_removeInstance_         (GblInstance* pInstance);
+// Fix for Windows: "Redefinition with different linkage"
+// Added GBL_EXPORT to all 3 and removed in implementation file gimbal_signal.c
+GBL_EXPORT extern GBL_RESULT    GblSignal_init_                   (GblContext* pCtx);
+GBL_EXPORT extern GBL_RESULT    GblSignal_final_                  (GblContext* pCtx);
+GBL_EXPORT extern GBL_RESULT    GblSignal_removeInstance_         (GblInstance* pInstance);
 
 extern GBL_RESULT    GblVariant_init_                  (GblContext* pCtx);
 extern GBL_RESULT    GblVariant_final_                 (GblContext* pCtx);

--- a/lib/source/utils/gimbal_date_time.c
+++ b/lib/source/utils/gimbal_date_time.c
@@ -961,7 +961,9 @@ static GBL_RESULT GblDateTime_convert_(const GblVariant* pVariant, GblVariant* p
     return GBL_TRUE;
 }
 
-GBL_EXPORT GblType GblDateTime_type(void) {
+// Fix Windows error as shared library: "Redefinition with different linkage"
+// Removed GBL_EXPORT
+GblType GblDateTime_type(void) {
     static GblType type = GBL_INVALID_TYPE;
 
     if(type == GBL_INVALID_TYPE) {


### PR DESCRIPTION
I needed to build libGimbal with symbol exporting enabled. It currently does not build as a shared library (DLL) on any platform, but I still needed symbols to export to avoid duplicating the library repeatedly in every compilation unit. 

To accomplish this, after setting the appropriate CMake flags, I also had to make the following code changes. I got the errors:

"Redefinition with different linkage" (mostly this one)
"Exported function must have external linkage"

To fix the errors, I ensured the `GBL_EXPORT` attribute was correctly used. In one instance, it was removed (GblClass_destruct_). Most fixes for this involved moving the `GBL_EXPORT` attribute from the implementation in the .c file to the declaration in the .h file.

The result allowed me to build libGimbal as a static library on Windows while still exporting symbols. This lets libGimbal be embedded inside `cascade.dll` but still export symbols so that component libraries that make use of Gimbal's utility don't have to include their own versions of it. 