### PR TITLE
Fixed a typo for GBL_UNIX in gimbal_compiler.h

### DIFF
--- a/lib/api/gimbal/preprocessor/gimbal_compiler.h
+++ b/lib/api/gimbal/preprocessor/gimbal_compiler.h
@@ -102,7 +102,7 @@
 #   define GBL_LINUX    1
 #elif __unix__ // all unices not caught above
     // Unix
-#   define GBL_UNUX 1
+#   define GBL_UNIX 1
 #elif defined(_POSIX_VERSION)
     // POSIX
 #   define GBL_POSIX


### PR DESCRIPTION
Thus far, searching the codebase for usage of GBL_UNIX, it seems blast radius is very small. Only this header was affected from what I've seen.