### PR TITLE
Fix: Missing GBL_DECLS_BEGIN/_END in gimbal_builtin_types.h

### DIFF
--- a/lib/api/gimbal/meta/types/gimbal_builtin_types.h
+++ b/lib/api/gimbal/meta/types/gimbal_builtin_types.h
@@ -17,6 +17,8 @@
 #ifndef GIMBAL_BUILTIN_TYPES_H
 #define GIMBAL_BUILTIN_TYPES_H
 
+GBL_DECLS_BEGIN
+
 /*! \name  Builtin Indices
  *  \brief Definitions providing each builtin type's index
  *  @{
@@ -83,5 +85,7 @@ typedef enum GblTypeRootFlags {
 
 //! Retrieves the GblType UUID associated with the given \p index of a builtin type
 GBL_EXPORT uintptr_t GblType_fromBuiltinIndex (size_t index) GBL_NOEXCEPT;
+
+GBL_DECLS_END
 
 #endif // GIMBAL_BUILTIN_TYPES_H


### PR DESCRIPTION
**Summary**

Submits a fix in `gimbal_builtin_types.h` for a missing pair of `GBL_DECLS_BEGIN` / `GBL_DECLS_END`.

This probably would manifested itself under:
* C++ project, that was using the `GBL_POINTER_TYPE` macro 
    * expands to `GblType_fromBuiltInIndex`, which is declared in patched header.
* Compiler info:
```
Apple clang version 16.0.0 (clang-1600.0.26.4)
Target: arm64-apple-darwin24.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

It would fail at link time, citing that it was unable to find a symbol for `GblType_fromBuiltInIndex`.

**Potential Test Case**

A minimal reproducible test case may look something like this:
```cpp

#include <gimbal/meta/types/gimbal_types.h>
#include <gimbal/meta/types/gimbal_pointer_type.h>

int main()
{
    const void* ExamplePointer = (void*)0xdeadbeef;
    GblVariant PtrVariant = { 0 };
    GblVariant_constructPointer(&PtrVariant, GBL_POINTER_TYPE, ExamplePointer);
}

```


This patch was tested on the cited compiler in the failing project and successfully built and ran the project. That project now translates QPushButton presses into -> GblClosure `OnClick` on a widget structures 😎 
