### PR TITLE
Fixing gimbal xxhash func NO THANKS TO LZ4

### DIFF
--- a/lib/source/algorithms/gimbal_hash.c
+++ b/lib/source/algorithms/gimbal_hash.c
@@ -392,7 +392,7 @@ GBL_EXPORT GblHash gblHashSha1(const void *pData, size_t len) {
 }
 
 GBL_EXPORT GblHash gblHashXx(const void* pData, size_t size) {
-    return XXH32(pData, size, gblSeed(0));
+    return LZ4_XXH32(pData, size, gblSeed(0));
 }
 
 


### PR DESCRIPTION
LZ4 really screwed us over with their namespacing change upstream.