### PR TITLE
Add support for KallistiOS GameCube (currently without compiler TLS)

### DIFF
--- a/lib/api/gimbal/core/gimbal_tls.h
+++ b/lib/api/gimbal/core/gimbal_tls.h
@@ -37,7 +37,7 @@
  *
  *  \sa GBL_TLS_LOAD()
  */
-#if !defined(GBL_PSP) && !GBL_TLS_EMULATED
+#if !defined(GBL_GAMECUBE) && !defined(GBL_PSP) && !GBL_TLS_EMULATED
 #   define GBL_TLS(type, name, ...) GBL_THREAD_LOCAL type name = __VA_ARGS__
 #else
 #   define GBL_TLS(type, name, ...) \
@@ -73,7 +73,7 @@
  *
  *  \sa GBL_TLS()
  */
-#if !defined(GBL_PSP) && !GBL_TLS_EMULATED
+#if !defined(GBL_GAMECUBE) && !defined(GBL_PSP) && !GBL_TLS_EMULATED
 #   define GBL_TLS_LOAD(name)    &name
 #else
 #   define GBL_TLS_LOAD(name)   tls_##name##_load_()

--- a/lib/api/gimbal/meta/types/gimbal_variant.h
+++ b/lib/api/gimbal/meta/types/gimbal_variant.h
@@ -533,7 +533,7 @@ GBL_EXPORT GblHash    GblVariant_hash    (GBL_CSELF)                   GBL_NOEXC
 
 GBL_DECLS_END
 
-#if !defined(GBL_DREAMCAST) && !defined(GBL_PSP)
+#if !defined(GBL_DREAMCAST) && !defined(GBL_GAMECUBE) && !defined(GBL_PSP)
 #   define GBL_VARIANT_CONSTRUCT_GENERIC_PLATFORM_ENTRIES()
 #else
 #   define GBL_VARIANT_CONSTRUCT_GENERIC_PLATFORM_ENTRIES() \

--- a/lib/api/gimbal/preprocessor/gimbal_compiler.h
+++ b/lib/api/gimbal/preprocessor/gimbal_compiler.h
@@ -94,6 +94,8 @@
 #   define GBL_ANDROID  1
 #elif defined(__DREAMCAST__)
 #   define GBL_DREAMCAST    1
+#elif defined(__GAMECUBE__)
+#   define GBL_GAMECUBE 1
 #elif defined(__PSP__)
 #   define GBL_PSP  1
 #elif defined(VITA)
@@ -229,7 +231,7 @@
 #else
 #   if defined(__DREAMCAST__)
 #       define GBL_THREAD_LOCAL     _Thread_local
-#   elif defined(__PSP__)
+#   elif defined(__GAMECUBE__) || defined(__PSP__)
 #       define GBL_THREAD_LOCAL
 #   else
 #       define GBL_THREAD_LOCAL     __thread
@@ -533,7 +535,8 @@
 #   if defined(__APPLE__)      || defined(__GLIBC__)  || \
        defined(__sun)          || defined(__CYGWIN__) || \
        defined(__EMSCRIPTEN__) || defined(VITA)       || \
-       defined(__DREAMCAST__)  || defined(PSP)
+       defined(__DREAMCAST__)  || defined(PSP)        || \
+       defined(__GAMECUBE__)
 #       include <alloca.h>        // Sane platforms
 #   elif defined(_WIN32)
 #       include <malloc.h>        // Windoez

--- a/lib/api/gimbal/test/gimbal_test_macros.h
+++ b/lib/api/gimbal/test/gimbal_test_macros.h
@@ -67,7 +67,7 @@ GBL_INLINE GblBool GBL_TEST_COMPARE_CMP_STR_    (const char* pActual, const char
                                                                                                      strcmp(pActual, pExpected) == 0); }
 GBL_DECLS_END
 
-#if defined(GBL_DREAMCAST)
+#if defined(GBL_DREAMCAST) || defined(GBL_GAMECUBE)
 #    define GBL_TEST_CMP_PLATFORM_ENTRIES()      \
         (size_t , GBL_TEST_COMPARE_CMP_UINT32_), \
         (int,     GBL_TEST_COMPARE_CMP_INT32_),

--- a/lib/source/algorithms/gimbal_hash.c
+++ b/lib/source/algorithms/gimbal_hash.c
@@ -94,7 +94,7 @@ GBL_INLINE void gblMurmurHash3_x86_32_(const void* key,
 #define	GBL_MURMUR_HASH_ROTL32_(x, r) ((x << r) | (x >> (32 - r)))
 #define GBL_MURMUR_HASH_FMIX32_(h) h^=h>>16; h*=0x85ebca6b; h^=h>>13; h*=0xc2b2ae35; h^=h>>16;
 // DO NOT DO UNALIGNED WORD ACCESSES ON THE RISC/EMBEDDED CPUS
-#if !defined(__DREAMCAST__) && !defined(__VITA__)
+#if !defined(__DREAMCAST__) && !defined(__GAMECUBE__) && !defined(__VITA__)
 #   define GBL_MURMUR_HASH_GET_BLOCK_(k, p, i) (k = p[i])
 #else
 #   define GBL_MURMUR_HASH_GET_BLOCK_(k, p, i) memcpy(&k, p + i, sizeof(uint32_t))


### PR DESCRIPTION
This allows libGimbal to build for KallistiOS GameCube.

Note that it still does not detect big endian properly at this time, despite the following lines being set in `${KOS_BASE}/utils/cmake/Platform/gamecube.cmake`:

```
set(CMAKE_C_BYTE_ORDER BIG_ENDIAN)
set(CMAKE_CXX_BYTE_ORDER BIG_ENDIAN)
```

A follow-up PR for compiler TLS support will be done when working in the KallistiOS GameCube port.