### PR TITLE
Fix endianness detection based on CMAKE_C_BYTE_ORDER

### DIFF
--- a/util/gimbal_utils.cmake
+++ b/util/gimbal_utils.cmake
@@ -118,11 +118,8 @@ function(GBL_BUILD_TIMESTAMP_DEFINE varName)
     set(GBL_BUILD_DEFINES ${GBL_BUILD_DEFINES} PARENT_SCOPE)
 endfunction()
 
-#include(TestBigEndian)
-
 function(GBL_BUILD_BIG_ENDIAN_DEFINE varName)
-#    TEST_BIG_ENDIAN(${varName})
-    if(CMAKE_C_BYTE_ORDER EQUAL BIG_ENDIAN)
+    if(CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
         GBL_BUILD_DEFINE(${varName} 1)
     else()
         GBL_BUILD_DEFINE(${varName} 0)


### PR DESCRIPTION
`CMAKE_C_BYTE_ORDER` is a string, so it must be checked using `STREQUAL`.