### PR TITLE
Rough changes for GameCube

### DIFF
--- a/lib/source/algorithms/gimbal_sha1.c
+++ b/lib/source/algorithms/gimbal_sha1.c
@@ -88,7 +88,7 @@ static void SHA1_Transform(uint32_t state[5], const uint8_t buffer[64]);
 /* blk0() and blk() perform the initial expand. */
 /* I got the idea of expanding during the round function from SSLeay */
 /* FIXME: can we do this in an endian-proof way? */
-#ifdef WORDS_BIGENDIAN
+#ifdef GBL_BIG_ENDIAN
 #define blk0(i) block->l[i]
 #else
 #define blk0(i) (block->l[i] = (rol(block->l[i],24)&0xFF00FF00) | (rol(block->l[i],8)&0x00FF00FF))

--- a/test/source/core/gimbal_thread_test_suite.c
+++ b/test/source/core/gimbal_thread_test_suite.c
@@ -328,7 +328,7 @@ GBL_TEST_CASE(detach)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(tlsSpawnThreads)
-#ifdef GBL_PSP
+#if defined(GBL_PSP) || defined(GBL_GAMECUBE)
     GBL_TEST_SKIP("Unimplemented on PSP without `thread_local` support!");
 #endif
 
@@ -348,7 +348,7 @@ GBL_TEST_CASE(tlsSpawnThreads)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(tlsInitBss)
-#ifdef GBL_PSP
+#if defined(GBL_PSP) || defined(GBL_GAMECUBE)
     GBL_TEST_SKIP("Unimplemented on PSP without `thread_local` support!");
 #endif
 
@@ -360,7 +360,7 @@ GBL_TEST_CASE(tlsInitBss)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(tlsInitData)
-#ifdef GBL_PSP
+#if defined(GBL_PSP) || defined(GBL_GAMECUBE)
     GBL_TEST_SKIP("Unimplemented on PSP without `thread_local` support!");
 #endif
 
@@ -370,7 +370,7 @@ GBL_TEST_CASE(tlsInitData)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(tlsInitAlignment)
-#ifdef GBL_PSP
+#if defined(GBL_PSP) || defined(GBL_GAMECUBE)
     GBL_TEST_SKIP("Unimplemented on PSP without `thread_local` support!");
 #endif
 
@@ -380,7 +380,7 @@ GBL_TEST_CASE(tlsInitAlignment)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(tlsReadWrite)
-#ifdef GBL_PSP
+#if defined(GBL_PSP) || defined(GBL_GAMECUBE)
     GBL_TEST_SKIP("Unimplemented on PSP without `thread_local` support!");
 #endif
 
@@ -391,7 +391,7 @@ GBL_TEST_CASE(tlsReadWrite)
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(tlsJoinThreads)
-#ifdef GBL_PSP
+#if defined(GBL_PSP) || defined(GBL_GAMECUBE)
     GBL_TEST_SKIP("Unimplemented on PSP without `thread_local` support!");
 #endif
 

--- a/test/source/meta/instances/gimbal_object_test_suite.c
+++ b/test/source/meta/instances/gimbal_object_test_suite.c
@@ -358,7 +358,8 @@ GBL_TEST_CASE(propertyGet)
                                     NULL);
     GBL_TEST_VERIFY(pObj1);
 
-    uint32_t    refCount    = 0;
+//    uint32_t    refCount    = 0;
+    uint16_t    refCount    = 0;
     void*       pUserdata   = NULL;
     const char* pName       = NULL;
     GblObject*  pParent     = NULL;


### PR DESCRIPTION
With these rough changes:

```
* [GblTestScenario] Ending Scenario: [libGimbalTests]
        * Runtime Statistics
                * Total Time (ms)     :             1469.346
                * Max Allocations     :                  120
                * Max Allocation Size :                 6412
                * Max Allocated Bytes :                28040
                * Remaining Allocs    :                   62
                * Remaining Bytes     :                15912
                * Seed                :                    0
        * Test Suite Totals
                * Total               :                   53
                * Passed              :                   52
                * Skipped             :                    1
                * Failed              :                    0
        * Test Case Totals
                * Total               :                 1065
                * Passed              :                 1052
                * Skipped             :                   13
                * Failed              :                    0
* ********************* [   PASS   ] *********************
```