### PR TITLE
GameCube: Use proper TLS instead of emulated TLS

### DIFF
--- a/lib/api/gimbal/core/gimbal_tls.h
+++ b/lib/api/gimbal/core/gimbal_tls.h
@@ -25,7 +25,7 @@
 #include <tinycthread.h>
 #include "../preprocessor/gimbal_compiler.h"
 
-#if defined(GBL_GAMECUBE) || defined(GBL_PSP)
+#if defined(GBL_PSP)
 #   define GBL_TLS_EMULATED 1
 #endif
 

--- a/lib/api/gimbal/preprocessor/gimbal_compiler.h
+++ b/lib/api/gimbal/preprocessor/gimbal_compiler.h
@@ -229,9 +229,9 @@
 #ifdef _MSC_VER
 #   define GBL_THREAD_LOCAL __declspec(thread)
 #else
-#   if defined(__DREAMCAST__)
+#   if defined(__DREAMCAST__) || defined(__GAMECUBE__)
 #       define GBL_THREAD_LOCAL     _Thread_local
-#   elif defined(__GAMECUBE__) || defined(__PSP__)
+#   elif defined(__PSP__)
 #       define GBL_THREAD_LOCAL
 #   else
 #       define GBL_THREAD_LOCAL     __thread

--- a/test/source/core/gimbal_thread_test_suite.c
+++ b/test/source/core/gimbal_thread_test_suite.c
@@ -327,7 +327,7 @@ GBL_TEST_CASE(detach)
     while(!pFixture->thread2Finished);
 GBL_TEST_CASE_END
 
-#ifdef GBL_TLS_EMULATED
+#if GBL_TLS_EMULATED
 #   define GBL_TEST_REQUIRE_TLS() \
         GBL_TEST_SKIP("Unimplemented for platforms requiring emulated TLS.")
 #else


### PR DESCRIPTION
KallistiOS for GameCube now has a proper static TLS implementation, which passes all libGimbal TLS-related tests.