### PR TITLE
[Fix] Fix building on latest MSVC 

### DIFF
--- a/lib/api/gimbal/preprocessor/gimbal_compiler.h
+++ b/lib/api/gimbal/preprocessor/gimbal_compiler.h
@@ -241,14 +241,14 @@
 // Floating-point precision directives
 #ifdef _MSC_VER
 #   define GBL_FP_FAST \
-        _Pragma("float_control(except, off)") \  // disable environment sensitivity
-        _Pragma("fenv_access(off)") \            // disable exception semantics
-        _Pragma("float_control(precise, off)") \ // disable precise semantics
-        _Pragma("fp_contract(on)")               // enable contractions
+        _Pragma("float_control(except, off)")       /* disable environment sensitivity */\
+        _Pragma("fenv_access(off)")                 /* disable exception semantics */\
+        _Pragma("float_control(precise, off)")      /* disable precise semantics */\
+        _Pragma("fp_contract(on)")                  /* enable contractions */
 #   define GBL_FP_PRECISE \
-        _Pragma("float_control(precise, on)") \  // enable precise semantics
-        _Pragma("fenv_access(on)")            \  // enable environment sensitivity
-        _Pragma("float_control(except, on)")     // enable exception semantics
+        _Pragma("float_control(precise, on)")       /* enable precise semantics */\
+        _Pragma("fenv_access(on)")                  /* enable environment sensitivity */\
+        _Pragma("float_control(except, on)")        /* enable exception semantics */
 #else
 #   define GBL_FP_FAST      __attribute__((optimize("-ffast-math")))
 #   define GBL_FP_PRECISE   __attribute__((optimize("-fno-fast-math")))

--- a/lib/source/utils/gimbal_uuid.c
+++ b/lib/source/utils/gimbal_uuid.c
@@ -37,21 +37,27 @@ GBL_EXPORT const char* GblUuid_string(const GblUuid* pSelf, char* pStrBuffer) {
     const char* pStr = NULL;
     GBL_CTX_BEGIN(NULL);
 
-    GBL_CTX_VERIFY(sprintf(pStrBuffer, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x"
+    size_t printedBytes =
+        sprintf(pStrBuffer, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x"
                                        "-%02x%02x%02x%02x%02x%02x",
 #if GBL_BIG_ENDIAN
+
                                        pSelf->bytes[ 3], pSelf->bytes[ 2], pSelf->bytes[ 1], pSelf->bytes[ 0],
                                        pSelf->bytes[ 5], pSelf->bytes[ 4], pSelf->bytes[ 7], pSelf->bytes[ 6],
                                        pSelf->bytes[ 8], pSelf->bytes[ 9], pSelf->bytes[10], pSelf->bytes[11],
                                        pSelf->bytes[12], pSelf->bytes[13], pSelf->bytes[14], pSelf->bytes[15])
+
 #else
+
                                        pSelf->bytes[ 0], pSelf->bytes[ 1], pSelf->bytes[ 2], pSelf->bytes[ 3],
                                        pSelf->bytes[ 4], pSelf->bytes[ 5], pSelf->bytes[ 6], pSelf->bytes[ 7],
                                        pSelf->bytes[ 8], pSelf->bytes[ 9], pSelf->bytes[10], pSelf->bytes[11],
                                        pSelf->bytes[12], pSelf->bytes[13], pSelf->bytes[14], pSelf->bytes[15])
+
 #endif
-                   == GBL_UUID_STRING_LENGTH,
-                   GBL_RESULT_ERROR_UNDERFLOW);
+        ;
+
+    GBL_CTX_VERIFY(printedBytes == GBL_UUID_STRING_LENGTH, GBL_RESULT_ERROR_UNDERFLOW);
     pStr = pStrBuffer;
     GBL_CTX_END_BLOCK();
     return pStr;


### PR DESCRIPTION
# Overview
MSVC builds were failing on latest master due to: 
* invalid formatting on `GBL_FP_FAST`/`GBL_FP_PRECISE` 
   * there was a space **AND** a comment **AFTER** the `\` in the `GBL_FP_FAST` / `GBL_FP_PRECISE` macros on the MSVC path. Tsk tsk tsk. 
* bad expansion in `GblUuid_string`.
   * this one clearly isn't an issue with Clang/GCC but MSVC did NOT like expanding `GBL_CTX_VERIFY` with the `#ifdef` inside of it. 

This PR introduces a commit to patch both of those, allowing latest master branch to compile with MSVC. 