### PR TITLE
[FIX] Use vsnprintf instead of vsprintf to avoid compiler deprecation warnings

### DIFF
--- a/lib/api/gimbal/core/gimbal_stack_frame.h
+++ b/lib/api/gimbal/core/gimbal_stack_frame.h
@@ -108,7 +108,7 @@ GBL_INLINE void GblCallRecord_construct(GblCallRecord* pRecord, GBL_RESULT resul
     pRecord->result = GBL_RESULT_UNKNOWN;
     pRecord->message[0] = '\0';
     pRecord->srcLocation.pFile = pRecord->srcLocation.pFunc = GBL_NULL;
-    if GBL_UNLIKELY(pFmt) vsprintf(pRecord->message, pFmt, varArgs);
+    if GBL_UNLIKELY(pFmt) vsnprintf(pRecord->message, GBL_CTX_RESULT_MSG_BUFFER_SIZE, pFmt, varArgs);
     va_end(varArgs);
     pRecord->srcLocation    = source;
     pRecord->result         = resultCode;


### PR DESCRIPTION
# Overview
Clang is one compiler that will produce warnings if it detects usage of `vsprintf` (or, `sprintf`) over `vsnprintf` / `snprintf`. Multiples of these warnings may be produced over the course of compilation, polutting the warnings list.

The origins of these warnings are in `gimbal_stack_frame.h`, the constructor for the stackframe will use `vsprintf` to populate the stack frame's `message` member. 

# Fix
To solve this, the `vsprintf` call in `gimbal_stack_frame.h` has been replaced with `vsnprintf`. For `n`, we are using `GBL_CTX_RESULT_MSG_BUFFER_SIZE`, which is the same size as `GblStackFrame::message`. 

# Testing
`GimbalTests` was ran before and after this change to ensure that this change did not produce any negative side effects. On my system, (MacBook Neo, macOS 26.4.1), 2 tests seem to fail always and there is a failure produced at the end. 

The output is consistent **before** and **after** the patch is applied, implying that these failures may be macOS-specific to begin with.

Ending test log:
```
* ********* Finished TestSuite [GblErrorTestSuite] *********
* [GblTestScenario] Ending Scenario: [libGimbalTests]
        * Runtime Statistics
                * Total Time (ms)     :              154.983
                * Max Allocations     :                  121
                * Max Allocation Size :                 8192
                * Max Allocated Bytes :                38360
                * Remaining Allocs    :                   91
                * Remaining Bytes     :                26368
                * Seed                :           1776103140
        * Test Suite Totals
                * Total               :                   53
                * Passed              :                   51
                * Skipped             :                    0
                * Failed              :                    2
        * Test Case Totals
                * Total               :                 1087
                * Passed              :                 1068
                * Skipped             :                   17
                * Failed              :                    2
* ********************* [   FAIL   ] *********************
        X Invalid Expression: Invalid Expression: !GblDoublyLinkedList_count(&pConnections->receiverConnections)
                @ instanceConnectionTableDestructor_(..): .../lib/source/meta/signals/gimbal_signal.c:216
```

The failures that pop-up seem to be TLS related:
```
* [ RUN       ]: GblThreadTestSuite::tlsInitAlignment
        X Invalid Expression: Invalid Expression: pFixture->pTestThreads[t]->tlsInitAlignPass
                @ GblThreadTestSuite_tlsInitAlignment_(..): .../test/source/core/gimbal_thread_test_suite.c:377
* [      FAIL ]: GblThreadTestSuite::tlsInitAlignment
* [ FINAL     ]: GblThreadTestSuite
        X Invalid Expression: Values differed [actual: 0x5, expected: 0x0]
                @ GblThreadTestSuite_final_(..): .../test/source/core/gimbal_thread_test_suite.c:217
* [      FAIL ]: GblThreadTestSuite
```