### PR TITLE
Add GblObject_foreachReverse macros

### DIFF
--- a/lib/api/gimbal/meta/instances/gimbal_object.h
+++ b/lib/api/gimbal/meta/instances/gimbal_object.h
@@ -65,6 +65,13 @@
 */
 #define GblObject_foreachChild(/*GBL_SELF, name, type=GblObject* */ ...) GblObject_foreachChildDefault_(__VA_ARGS__)
 
+/*! \brief For-loop style iteration over the children of a GblObject, in reverse order
+ *
+ *  Iterates over every child within the given object, setting the \p item variable to the current child.
+ *  Optionally takes in a \p type parameter to specify the type of the children to iterate over.
+*/
+#define GblObject_foreachChildReverse(/*GBL_SELF, name, type=GblObject* */ ...) GblObject_foreachChildReverseDefault_(__VA_ARGS__)
+
 #define GBL_SELF_TYPE GblObject
 
 GBL_DECLS_BEGIN
@@ -418,9 +425,7 @@ GBL_DECLS_END
 #define GblObject_foreachChildDefault__(self, name, type, ...) \
     GblObject_foreachChildImpl_(self, name, type)
 #define GblObject_foreachChildImpl_(self, name, type)                               \
-    for(type name       =   GblObject_childFirst(self) ?                            \
-                            (type)GblObject_childFirst(self) :                      \
-                            NULL,                                                   \
+    for(type name       =   (type)GblObject_childFirst(self),                       \
         *name##_next_   =   name ?                                                  \
                             (type)GblObject_siblingNext(GBL_OBJECT(name)) :         \
                             NULL;                                                   \
@@ -430,6 +435,23 @@ GBL_DECLS_END
         name = name##_next_, name##_next_ = name ?                                  \
                              (type)GblObject_siblingNext(GBL_OBJECT(name))          \
                              : NULL)
+
+#define GblObject_foreachChildReverseDefault_(...) \
+    GblObject_foreachChildReverseDefault__(__VA_ARGS__, GblObject*)
+#define GblObject_foreachChildReverseDefault__(self, name, type, ...) \
+    GblObject_foreachChildReverseImpl_(self, name, type)
+#define GblObject_foreachChildReverseImpl_(self, name, type)                        \
+    for(type name       =   (type)GblObject_childLast(self),                        \
+        *name##_prev_   =   name ?                                                  \
+                            (type)GblObject_siblingPrevious(GBL_OBJECT(name)) :     \
+                            NULL;                                                   \
+                                                                                    \
+        name;                                                                       \
+                                                                                    \
+        name = name##_prev_, name##_prev_ = name ?                                  \
+                             (type)GblObject_siblingPrevious(GBL_OBJECT(name))      \
+                             : NULL)
+
 ///\endcond
 
 #undef GBL_SELF_TYPE

--- a/lib/api/gimbal/preprocessor/gimbal_macro_utils.h
+++ b/lib/api/gimbal/preprocessor/gimbal_macro_utils.h
@@ -107,7 +107,7 @@ extern "C" {
 }
 #endif
 
-#define GBL_SCOPE(begin, end) for (int GBL_APPEND_LINE(gblscope_) = ((begin), 0); GBL_APPEND_LINE(gblscope_) < 1; ++GBL_APPEND_LINE(gblscope_), (end))
+#define GBL_SCOPE(begin, end) for (int GBL_APPEND_LINE(gblscope_) = ((void)(begin), 0); GBL_APPEND_LINE(gblscope_) < 1; ++GBL_APPEND_LINE(gblscope_), (end))
 #define GBL_SCOPE_EXIT continue
 
 #define GBL_APPEND_LINE(a)  GBL_GLUE(GBL_GLUE(a, ), __LINE__)

--- a/test/source/meta/instances/gimbal_object_test_suite.c
+++ b/test/source/meta/instances/gimbal_object_test_suite.c
@@ -1016,6 +1016,22 @@ GBL_TEST_CASE(foreachChild)
     GBL_UNREF(pParent);
 GBL_TEST_CASE_END
 
+GBL_TEST_CASE(foreachChildMutating)
+    GblObject* pParent = GBL_NEW(GblObject);
+    GblObject* pChild1 = GBL_NEW(GblObject, "name", "Child1", "parent", pParent);
+    GblObject* pChild2 = GBL_NEW(GblObject, "name", "Child2", "parent", pParent);
+    GblObject* pChild3 = GBL_NEW(GblObject, "name", "Child3", "parent", pParent);
+    GblObject* pChild4 = GBL_NEW(GblObject, "name", "Child4", "parent", pParent);
+
+    GblObject_foreachChild(pParent, pChild) {
+        GBL_TEST_COMPARE(GblObject_name(pChild),
+                         GblObject_name(GblObject_childFirst(pParent)));
+        GBL_UNREF(pChild);
+    }
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
 GBL_TEST_CASE(foreachChildType)
     GblObject*  pParent = GBL_NEW(GblObject);
     TestObject* pChild1 = GBL_NEW(TestObject, "name", "Child1", "parent", pParent);
@@ -1032,6 +1048,61 @@ GBL_TEST_CASE(foreachChildType)
         GBL_TEST_COMPARE(strcmp(pChild->stringer, "INVALID"), 0);
         GBL_TEST_COMPARE(pClass->staticInt32, 77);
         ++index;
+    }
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(foreachChildReverse)
+    GblObject* pParent = GBL_NEW(GblObject);
+    GblObject* pChild1 = GBL_NEW(GblObject, "name", "Child1", "parent", pParent);
+    GblObject* pChild2 = GBL_NEW(GblObject, "name", "Child2", "parent", pParent);
+    GblObject* pChild3 = GBL_NEW(GblObject, "name", "Child3", "parent", pParent);
+    GblObject* pChild4 = GBL_NEW(GblObject, "name", "Child4", "parent", pParent);
+
+    int index = 3;
+
+    GblObject_foreachChildReverse(pParent, pChild) {
+        GBL_TEST_COMPARE(GblObject_name(pChild),
+                         GblObject_name(GblObject_findChildByIndex(pParent, index)));
+        --index;
+    }
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(foreachChildReverseMutating)
+    GblObject* pParent = GBL_NEW(GblObject);
+    GblObject* pChild1 = GBL_NEW(GblObject, "name", "Child1", "parent", pParent);
+    GblObject* pChild2 = GBL_NEW(GblObject, "name", "Child2", "parent", pParent);
+    GblObject* pChild3 = GBL_NEW(GblObject, "name", "Child3", "parent", pParent);
+    GblObject* pChild4 = GBL_NEW(GblObject, "name", "Child4", "parent", pParent);
+
+    GblObject_foreachChildReverse(pParent, pChild) {
+        GBL_TEST_COMPARE(GblObject_name(pChild),
+                         GblObject_name(GblObject_childLast(pParent)));
+        GBL_UNREF(pChild);
+    }
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(foreachChildReverseType)
+    GblObject*  pParent = GBL_NEW(GblObject);
+    TestObject* pChild1 = GBL_NEW(TestObject, "name", "Child1", "parent", pParent);
+    TestObject* pChild2 = GBL_NEW(TestObject, "name", "Child2", "parent", pParent);
+    TestObject* pChild3 = GBL_NEW(TestObject, "name", "Child3", "parent", pParent);
+    TestObject* pChild4 = GBL_NEW(TestObject, "name", "Child4", "parent", pParent);
+
+    int index = 3;
+
+    GblObject_foreachChildReverse(pParent, pChild, TestObject*) {
+        TestObjectClass* pClass = TEST_OBJECT_GET_CLASS(pChild);
+        GBL_TEST_COMPARE(GblObject_name(GBL_OBJECT(pChild)),
+                         GblObject_name(GblObject_findChildByIndex(pParent, index)));
+        GBL_TEST_COMPARE(strcmp(pChild->stringer, "INVALID"), 0);
+        GBL_TEST_COMPARE(pClass->staticInt32, 77);
+        --index;
     }
 
     GBL_UNREF(pParent);
@@ -1230,7 +1301,11 @@ GBL_TEST_REGISTER(newDefault,
                   childrenProperty,
                   childrenPropertyVariant,
                   foreachChild,
+                  foreachChildMutating,
                   foreachChildType,
+                  foreachChildReverse,
+                  foreachChildReverseMutating,
+                  foreachChildReverseType,
                   addChildren,
                   removeChildren,
                   clearChildren,


### PR DESCRIPTION
## Summary of Changes

### gimbal_object
* Added **`GblObject_foreachChildReverse()`**
* Simplified original foreachChild macro

### gimbal_object_test_suite
* Added unit tests for the new method
* Added an extra unit test for the original foreachChild macro

### gimbal_macro_utils
* Quick change to fix compiler warning
