### PR TITLE
Add new GblVariant_asXXXX methods

### DIFF
--- a/lib/api/gimbal/meta/types/gimbal_variant.h
+++ b/lib/api/gimbal/meta/types/gimbal_variant.h
@@ -326,81 +326,119 @@ GBL_EXPORT const char* GblVariant_typeName (GBL_CSELF) GBL_NOEXCEPT;
  *  @{
  */
 //! Attempts to retrieve a copy of the variant's value and store it into the provided pointer
-GBL_EXPORT GBL_RESULT    GblVariant_valueCopy   (GBL_CSELF, ...)          GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueCopy    (GBL_CSELF, ...)                          GBL_NOEXCEPT;
 //! va_list* variant of GblVariant_valueCopy(), where the destination pointer comes from a va_list*
-GBL_EXPORT GBL_RESULT    GblVariant_valueCopyVa (GBL_CSELF, va_list* pVa) GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueCopyVa  (GBL_CSELF, va_list* pVa)                 GBL_NOEXCEPT;
 //! Attempts to retrieve the actual value stored within the variant and store it into the provided pointer (no movement or copying)
-GBL_EXPORT GBL_RESULT    GblVariant_valuePeek   (GBL_CSELF, ...)          GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valuePeek    (GBL_CSELF, ...)                          GBL_NOEXCEPT;
 //! va_list* variant of GblVariant_valuePeek(), where destination pointer comes from a va_list*
-GBL_EXPORT GBL_RESULT    GblVariant_valuePeekVa (GBL_SELF, va_list* pVa)  GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valuePeekVa  (GBL_SELF, va_list* pVa)                  GBL_NOEXCEPT;
 //! Attempts to move the value stored within the variant out of it and into the provided pointer
-GBL_EXPORT GBL_RESULT    GblVariant_valueMove   (GBL_SELF, ...)           GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueMove    (GBL_SELF, ...)                           GBL_NOEXCEPT;
 //! va_list* variant of GblVariant_valueMove(), where destination pointer comes from a va_list*
-GBL_EXPORT GBL_RESULT    GblVariant_valueMoveVa (GBL_SELF, va_list* pVa)  GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueMoveVa  (GBL_SELF, va_list* pVa)                  GBL_NOEXCEPT;
 //! Returns GBL_TRUE if the value held by the given variant is not of GBL_INVALID_TYPE
-GBL_EXPORT GblBool       GblVariant_isValid     (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblBool       GblVariant_isValid      (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Returns GBL_TRUE if the value held by the variant is not of type GBL_NIL_TYPE
-GBL_EXPORT GblBool       GblVariant_isNil       (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblBool       GblVariant_isNil        (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a bool, raising an error upon type mismatch
-GBL_EXPORT GblBool       GblVariant_bool        (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblBool       GblVariant_bool         (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a char, raising an error upon type mismatch
-GBL_EXPORT char          GblVariant_char        (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT char          GblVariant_char         (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint8, raising an error upon type mismatch
-GBL_EXPORT uint8_t       GblVariant_uint8       (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT uint8_t       GblVariant_uint8        (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint16, raising an error upon type mismatch
-GBL_EXPORT uint16_t      GblVariant_uint16      (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT uint16_t      GblVariant_uint16       (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as an int16, raising an error upon type mismatch
-GBL_EXPORT int16_t       GblVariant_int16       (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT int16_t       GblVariant_int16        (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint32, raising an error upon type mismatch
-GBL_EXPORT uint32_t      GblVariant_uint32      (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT uint32_t      GblVariant_uint32       (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as an int32, raising an error upon type mismatch
-GBL_EXPORT int32_t       GblVariant_int32       (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT int32_t       GblVariant_int32        (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint64, raising an error upon type mismatch
-GBL_EXPORT uint64_t      GblVariant_uint64      (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT uint64_t      GblVariant_uint64       (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as an int64, raising an error upon type mismatch
-GBL_EXPORT int64_t       GblVariant_int64       (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT int64_t       GblVariant_int64        (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic enum value, raising an error upon type mismatch
-GBL_EXPORT GblEnum       GblVariant_enum        (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblEnum       GblVariant_enum         (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic GblFlags value, raising an error upon type mismatch
-GBL_EXPORT GblFlags      GblVariant_flags       (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblFlags      GblVariant_flags        (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a float, raising an error upon type mismatch
-GBL_EXPORT float         GblVariant_float       (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT float         GblVariant_float        (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a double, raising an error upon type mismatch
-GBL_EXPORT double        GblVariant_double      (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT double        GblVariant_double       (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a string, raising an error upon type mismatch
-GBL_EXPORT GblStringRef* GblVariant_string      (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblStringRef* GblVariant_string       (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a string, returning it within a view, raising an error upon type mismatch
-GBL_EXPORT GblStringView GblVariant_stringView  (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblStringView GblVariant_stringView   (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a GblType, raising an error upon type mismatch
-GBL_EXPORT GblType       GblVariant_typeValue   (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblType       GblVariant_typeValue    (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_pointer     (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_pointer      (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a size_t, raising an error upon type mismatch
-GBL_EXPORT size_t        GblVariant_size        (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT size_t        GblVariant_size         (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a GblDateTime, raising an error upon type mismatch
-GBL_EXPORT GblDateTime*  GblVariant_dateTime    (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblDateTime*  GblVariant_dateTime     (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch a copy of the value of the variant as a generic opaque pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_opaqueCopy  (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_opaqueCopy   (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to take the value of the variant (claiming ownerships) as a generic opaque pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_opaqueMove  (GBL_SELF)                GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_opaqueMove   (GBL_SELF)                                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic opaque pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_opaquePeek  (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_opaquePeek   (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a GblInstance derived type, returning a pointer to it
-GBL_EXPORT GblInstance*  GblVariant_instance    (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblInstance*  GblVariant_instance     (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch a copy of the value of the variant by making a new generic GblBox reference, raising an error upon type mismatch
-GBL_EXPORT GblBox*       GblVariant_boxCopy     (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblBox*       GblVariant_boxCopy      (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to take the value stored within the variant as generic GblBox pointer, claiming ownerships of it
-GBL_EXPORT GblBox*       GblVariant_boxMove     (GBL_SELF)                GBL_NOEXCEPT;
+GBL_EXPORT GblBox*       GblVariant_boxMove      (GBL_SELF)                                GBL_NOEXCEPT;
 //! Attempts to fetch the value stored within the variant as a pointer to a GblBox derived type
-GBL_EXPORT GblBox*       GblVariant_boxPeek     (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblBox*       GblVariant_boxPeek      (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to fetch a copy of the value of the variant by making a new generic GblObject reference, raising an error upon type mismatch
-GBL_EXPORT GblObject*    GblVariant_objectCopy  (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblObject*    GblVariant_objectCopy   (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Attempts to take the value stored within the variant as generic GblObject pointer, claiming ownerships of it
-GBL_EXPORT GblObject*    GblVariant_objectMove  (GBL_SELF)                GBL_NOEXCEPT;
+GBL_EXPORT GblObject*    GblVariant_objectMove   (GBL_SELF)                                GBL_NOEXCEPT;
 //! Attempts to fetch the value stored within the variant as a pointer to a GblObject derived type
-GBL_EXPORT GblObject*    GblVariant_objectPeek  (GBL_CSELF)               GBL_NOEXCEPT;
+GBL_EXPORT GblObject*    GblVariant_objectPeek   (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT GBL_RESULT    GblVariant_asValue      (GBL_CSELF, GblType type, ...)            GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT GBL_RESULT    GblVariant_asValueVa    (GBL_CSELF, GblType type, va_list* pList) GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT GblBool       GblVariant_asBool       (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT char          GblVariant_asChar       (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT uint8_t       GblVariant_asUint8      (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT uint16_t      GblVariant_asUint16     (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT int16_t       GblVariant_asInt16      (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT uint32_t      GblVariant_asUint32     (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT int32_t       GblVariant_asInt32      (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT uint64_t      GblVariant_asUint64     (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT int64_t       GblVariant_asInt64      (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT GblEnum       GblVariant_asEnum       (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT GblFlags      GblVariant_asFlags      (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT float         GblVariant_asFloat      (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT double        GblVariant_asDouble     (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT void*         GblVariant_asPointer    (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT GblStringRef* GblVariant_asString     (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT size_t        GblVariant_asSize       (GBL_CSELF)                               GBL_NOEXCEPT;
+//! TODO: doc
+GBL_EXPORT GblDateTime*  GblVariant_asDateTime   (GBL_CSELF)                               GBL_NOEXCEPT;
 //! @}
-//!
+
 /*! \name Table Accessors
  *  \brief Methods for managing and manipulating variants as tables
  *  \relatesalso GblVariant

--- a/lib/api/gimbal/meta/types/gimbal_variant.h
+++ b/lib/api/gimbal/meta/types/gimbal_variant.h
@@ -326,79 +326,86 @@ GBL_EXPORT const char* GblVariant_typeName (GBL_CSELF) GBL_NOEXCEPT;
  *  @{
  */
 //! Attempts to retrieve a copy of the variant's value and store it into the provided pointer
-GBL_EXPORT GBL_RESULT    GblVariant_valueCopy    (GBL_CSELF, ...)                          GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueCopy    (GBL_CSELF, ...)           GBL_NOEXCEPT;
 //! va_list* variant of GblVariant_valueCopy(), where the destination pointer comes from a va_list*
-GBL_EXPORT GBL_RESULT    GblVariant_valueCopyVa  (GBL_CSELF, va_list* pVa)                 GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueCopyVa  (GBL_CSELF, va_list* pVa)  GBL_NOEXCEPT;
 //! Attempts to retrieve the actual value stored within the variant and store it into the provided pointer (no movement or copying)
-GBL_EXPORT GBL_RESULT    GblVariant_valuePeek    (GBL_CSELF, ...)                          GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valuePeek    (GBL_CSELF, ...)           GBL_NOEXCEPT;
 //! va_list* variant of GblVariant_valuePeek(), where destination pointer comes from a va_list*
-GBL_EXPORT GBL_RESULT    GblVariant_valuePeekVa  (GBL_SELF, va_list* pVa)                  GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valuePeekVa  (GBL_SELF, va_list* pVa)   GBL_NOEXCEPT;
 //! Attempts to move the value stored within the variant out of it and into the provided pointer
-GBL_EXPORT GBL_RESULT    GblVariant_valueMove    (GBL_SELF, ...)                           GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueMove    (GBL_SELF, ...)            GBL_NOEXCEPT;
 //! va_list* variant of GblVariant_valueMove(), where destination pointer comes from a va_list*
-GBL_EXPORT GBL_RESULT    GblVariant_valueMoveVa  (GBL_SELF, va_list* pVa)                  GBL_NOEXCEPT;
+GBL_EXPORT GBL_RESULT    GblVariant_valueMoveVa  (GBL_SELF, va_list* pVa)   GBL_NOEXCEPT;
 //! Returns GBL_TRUE if the value held by the given variant is not of GBL_INVALID_TYPE
-GBL_EXPORT GblBool       GblVariant_isValid      (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblBool       GblVariant_isValid      (GBL_CSELF)                GBL_NOEXCEPT;
 //! Returns GBL_TRUE if the value held by the variant is not of type GBL_NIL_TYPE
-GBL_EXPORT GblBool       GblVariant_isNil        (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblBool       GblVariant_isNil        (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a bool, raising an error upon type mismatch
-GBL_EXPORT GblBool       GblVariant_bool         (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblBool       GblVariant_bool         (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a char, raising an error upon type mismatch
-GBL_EXPORT char          GblVariant_char         (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT char          GblVariant_char         (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint8, raising an error upon type mismatch
-GBL_EXPORT uint8_t       GblVariant_uint8        (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT uint8_t       GblVariant_uint8        (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint16, raising an error upon type mismatch
-GBL_EXPORT uint16_t      GblVariant_uint16       (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT uint16_t      GblVariant_uint16       (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as an int16, raising an error upon type mismatch
-GBL_EXPORT int16_t       GblVariant_int16        (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT int16_t       GblVariant_int16        (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint32, raising an error upon type mismatch
-GBL_EXPORT uint32_t      GblVariant_uint32       (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT uint32_t      GblVariant_uint32       (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as an int32, raising an error upon type mismatch
-GBL_EXPORT int32_t       GblVariant_int32        (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT int32_t       GblVariant_int32        (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a uint64, raising an error upon type mismatch
-GBL_EXPORT uint64_t      GblVariant_uint64       (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT uint64_t      GblVariant_uint64       (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as an int64, raising an error upon type mismatch
-GBL_EXPORT int64_t       GblVariant_int64        (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT int64_t       GblVariant_int64        (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic enum value, raising an error upon type mismatch
-GBL_EXPORT GblEnum       GblVariant_enum         (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblEnum       GblVariant_enum         (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic GblFlags value, raising an error upon type mismatch
-GBL_EXPORT GblFlags      GblVariant_flags        (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblFlags      GblVariant_flags        (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a float, raising an error upon type mismatch
-GBL_EXPORT float         GblVariant_float        (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT float         GblVariant_float        (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a double, raising an error upon type mismatch
-GBL_EXPORT double        GblVariant_double       (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT double        GblVariant_double       (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a string, raising an error upon type mismatch
-GBL_EXPORT GblStringRef* GblVariant_string       (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblStringRef* GblVariant_string       (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a string, returning it within a view, raising an error upon type mismatch
-GBL_EXPORT GblStringView GblVariant_stringView   (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblStringView GblVariant_stringView   (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a GblType, raising an error upon type mismatch
-GBL_EXPORT GblType       GblVariant_typeValue    (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblType       GblVariant_typeValue    (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_pointer      (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_pointer      (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a size_t, raising an error upon type mismatch
-GBL_EXPORT size_t        GblVariant_size         (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT size_t        GblVariant_size         (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a GblDateTime, raising an error upon type mismatch
-GBL_EXPORT GblDateTime*  GblVariant_dateTime     (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblDateTime*  GblVariant_dateTime     (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch a copy of the value of the variant as a generic opaque pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_opaqueCopy   (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_opaqueCopy   (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to take the value of the variant (claiming ownerships) as a generic opaque pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_opaqueMove   (GBL_SELF)                                GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_opaqueMove   (GBL_SELF)                 GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a generic opaque pointer, raising an error upon type mismatch
-GBL_EXPORT void*         GblVariant_opaquePeek   (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT void*         GblVariant_opaquePeek   (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch the value of the variant as a GblInstance derived type, returning a pointer to it
-GBL_EXPORT GblInstance*  GblVariant_instance     (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblInstance*  GblVariant_instance     (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch a copy of the value of the variant by making a new generic GblBox reference, raising an error upon type mismatch
-GBL_EXPORT GblBox*       GblVariant_boxCopy      (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblBox*       GblVariant_boxCopy      (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to take the value stored within the variant as generic GblBox pointer, claiming ownerships of it
-GBL_EXPORT GblBox*       GblVariant_boxMove      (GBL_SELF)                                GBL_NOEXCEPT;
+GBL_EXPORT GblBox*       GblVariant_boxMove      (GBL_SELF)                 GBL_NOEXCEPT;
 //! Attempts to fetch the value stored within the variant as a pointer to a GblBox derived type
-GBL_EXPORT GblBox*       GblVariant_boxPeek      (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblBox*       GblVariant_boxPeek      (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to fetch a copy of the value of the variant by making a new generic GblObject reference, raising an error upon type mismatch
-GBL_EXPORT GblObject*    GblVariant_objectCopy   (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblObject*    GblVariant_objectCopy   (GBL_CSELF)                GBL_NOEXCEPT;
 //! Attempts to take the value stored within the variant as generic GblObject pointer, claiming ownerships of it
-GBL_EXPORT GblObject*    GblVariant_objectMove   (GBL_SELF)                                GBL_NOEXCEPT;
+GBL_EXPORT GblObject*    GblVariant_objectMove   (GBL_SELF)                 GBL_NOEXCEPT;
 //! Attempts to fetch the value stored within the variant as a pointer to a GblObject derived type
-GBL_EXPORT GblObject*    GblVariant_objectPeek   (GBL_CSELF)                               GBL_NOEXCEPT;
+GBL_EXPORT GblObject*    GblVariant_objectPeek   (GBL_CSELF)                GBL_NOEXCEPT;
+//! @}
+
+/*! \name Conditional Conversions
+ *  \brief TODO: DOCUMENT THIS
+ *  \relatesalso GblVariant
+ *  @{
+ */
 //! TODO: doc
 GBL_EXPORT GBL_RESULT    GblVariant_asValue      (GBL_CSELF, GblType type, ...)            GBL_NOEXCEPT;
 //! TODO: doc

--- a/lib/api/gimbal/meta/types/gimbal_variant.h
+++ b/lib/api/gimbal/meta/types/gimbal_variant.h
@@ -406,8 +406,8 @@ GBL_EXPORT GblObject*    GblVariant_objectPeek   (GBL_CSELF)                GBL_
  *  \relatesalso GblVariant
  *  @{
  */
-//! Attempts to retrieve the variant's value as the specified type and store it in the provided destination.
-//! If the requested type is reference-counted, the returned value is a reference owned by the caller.
+/*! Attempts to retrieve the variant's value as the specified type and store it in the provided destination.
+    \warning If the requested type is reference-counted, the returned value is a reference owned by the caller. */
 GBL_EXPORT GBL_RESULT    GblVariant_asValue      (GBL_CSELF, GblType type, ...)            GBL_NOEXCEPT;
 //! va_list* variation of GblVariant_asValue().
 GBL_EXPORT GBL_RESULT    GblVariant_asValueVa    (GBL_CSELF, GblType type, va_list* pList) GBL_NOEXCEPT;
@@ -440,13 +440,13 @@ GBL_EXPORT float         GblVariant_asFloat      (GBL_CSELF)                    
 GBL_EXPORT double        GblVariant_asDouble     (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Convenience method that attempts to retrieve the variant's value as a pointer.
 GBL_EXPORT void*         GblVariant_asPointer    (GBL_CSELF)                               GBL_NOEXCEPT;
-//! Convenience method that attempts to retrieve the variant's value as a GblStringRef.
-//! The returned reference is owned by the caller.
+/*! Convenience method that attempts to retrieve the variant's value as a GblStringRef.
+    \warning The returned reference is owned by the caller. */
 GBL_EXPORT GblStringRef* GblVariant_asString     (GBL_CSELF)                               GBL_NOEXCEPT;
 //! Convenience method that attempts to retrieve the variant's value as a size_t.
 GBL_EXPORT size_t        GblVariant_asSize       (GBL_CSELF)                               GBL_NOEXCEPT;
-//! Convenience method that attempts to retrieve the variant's value as a GblDateTime reference.
-//! The returned reference is owned by the caller.
+/*! Convenience method that attempts to retrieve the variant's value as a GblDateTime reference.
+    \warning The returned reference is owned by the caller. */
 GBL_EXPORT GblDateTime*  GblVariant_asDateTime   (GBL_CSELF)                               GBL_NOEXCEPT;
 //! @}
 

--- a/lib/api/gimbal/meta/types/gimbal_variant.h
+++ b/lib/api/gimbal/meta/types/gimbal_variant.h
@@ -402,47 +402,51 @@ GBL_EXPORT GblObject*    GblVariant_objectPeek   (GBL_CSELF)                GBL_
 //! @}
 
 /*! \name Conditional Conversions
- *  \brief TODO: DOCUMENT THIS
+ *  \brief Methods for retrieving values in a requested type without modifying the source variant.
  *  \relatesalso GblVariant
  *  @{
  */
-//! TODO: doc
+//! Attempts to retrieve the variant's value as the specified type and store it in the provided destination.
+//! If the requested type is reference-counted, the returned value is a reference owned by the caller.
 GBL_EXPORT GBL_RESULT    GblVariant_asValue      (GBL_CSELF, GblType type, ...)            GBL_NOEXCEPT;
-//! TODO: doc
+//! va_list* variation of GblVariant_asValue().
 GBL_EXPORT GBL_RESULT    GblVariant_asValueVa    (GBL_CSELF, GblType type, va_list* pList) GBL_NOEXCEPT;
-//! TODO: doc
+
+//! Convenience method that attempts to retrieve the variant's value as a bool.
 GBL_EXPORT GblBool       GblVariant_asBool       (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a char.
 GBL_EXPORT char          GblVariant_asChar       (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a uint8.
 GBL_EXPORT uint8_t       GblVariant_asUint8      (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a uint16.
 GBL_EXPORT uint16_t      GblVariant_asUint16     (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as an int16.
 GBL_EXPORT int16_t       GblVariant_asInt16      (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a uint32.
 GBL_EXPORT uint32_t      GblVariant_asUint32     (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as an int32.
 GBL_EXPORT int32_t       GblVariant_asInt32      (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a uint64.
 GBL_EXPORT uint64_t      GblVariant_asUint64     (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as an int64.
 GBL_EXPORT int64_t       GblVariant_asInt64      (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as an enum.
 GBL_EXPORT GblEnum       GblVariant_asEnum       (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a flags.
 GBL_EXPORT GblFlags      GblVariant_asFlags      (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a float.
 GBL_EXPORT float         GblVariant_asFloat      (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a double.
 GBL_EXPORT double        GblVariant_asDouble     (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a pointer.
 GBL_EXPORT void*         GblVariant_asPointer    (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a GblStringRef.
+//! The returned reference is owned by the caller.
 GBL_EXPORT GblStringRef* GblVariant_asString     (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a size_t.
 GBL_EXPORT size_t        GblVariant_asSize       (GBL_CSELF)                               GBL_NOEXCEPT;
-//! TODO: doc
+//! Convenience method that attempts to retrieve the variant's value as a GblDateTime reference.
+//! The returned reference is owned by the caller.
 GBL_EXPORT GblDateTime*  GblVariant_asDateTime   (GBL_CSELF)                               GBL_NOEXCEPT;
 //! @}
 

--- a/lib/source/meta/classes/gimbal_primitives.c
+++ b/lib/source/meta/classes/gimbal_primitives.c
@@ -937,7 +937,7 @@ static GBL_RESULT stringGet_(GblVariant* pVariant, size_t  argc, GblVariant* pAr
     GBL_CTX_VERIFY_TYPE(pArgs[0].type, GBL_POINTER_TYPE);
     GBL_CTX_VERIFY_POINTER(pArgs[0].pVoid);
     if(op & GBL_IVARIANT_OP_FLAG_GET_VALUE_COPY) {
-        *((const char**)pArgs->pVoid) = GblStringView_strdup(GblStringRef_view(pVariant->pString));
+        *((GblStringRef**)pArgs->pVoid) = GblStringRef_ref(pVariant->pString);
     } else if(op & GBL_IVARIANT_OP_FLAG_GET_VALUE_PEEK) {
         *((const char**)pArgs->pVoid) = pVariant->pString? pVariant->pString : "";
     } else if(op & GBL_IVARIANT_OP_FLAG_GET_VALUE_MOVE) {

--- a/lib/source/meta/instances/gimbal_object.c
+++ b/lib/source/meta/instances/gimbal_object.c
@@ -1760,7 +1760,7 @@ static GBL_RESULT GblObject_property_(const GblObject* pSelf, const GblProperty*
             GblVariant_setNil(pValue);
     } break;
     case GblObject_Property_Id_parent:
-        GblVariant_setValueMove(pValue,
+        GblVariant_setValueCopy(pValue,
                                 pProp->valueType,
                                 GblObject_parent(pSelf));
         break;

--- a/lib/source/meta/types/gimbal_variant.c
+++ b/lib/source/meta/types/gimbal_variant.c
@@ -564,6 +564,142 @@ GBL_EXPORT GblObject* GblVariant_objectPeek(const GblVariant* pSelf) {
     return pObject;
 }
 
+GBL_EXPORT GBL_RESULT GblVariant_asValue(const GblVariant* pSelf, GblType type, ...) {
+    GBL_RESULT result;
+
+    va_list varArgs;
+    va_start(varArgs, type);
+
+    result = GblVariant_asValueVa(pSelf,
+                                  type,
+                                  &varArgs);
+
+    va_end(varArgs);
+
+    return result;
+}
+
+GBL_EXPORT GBL_RESULT GblVariant_asValueVa(const GblVariant* pSelf, GblType type, va_list* pList) {
+    GBL_CTX_BEGIN(NULL);
+
+    if(GblVariant_typeOf(pSelf) == type) {
+        GBL_CTX_CALL(GblVariant_valueCopyVa(pSelf, pList));
+    } else {
+        GBL_VARIANT(tmp);
+
+        GBL_CTX_CALL(GblVariant_constructDefault(&tmp, type));
+        GBL_CTX_VERIFY_CALL(GblVariant_convert(pSelf, &tmp));
+
+        GBL_CTX_CALL(GblVariant_valueMoveVa(&tmp, pList));
+
+        GblVariant_destruct(&tmp);
+    }
+
+    GBL_CTX_END();
+}
+
+GBL_EXPORT GblBool GblVariant_asBool(const GblVariant* pSelf) {
+    GblBool value = GBL_FALSE;
+    GblVariant_asValue(pSelf, GBL_BOOL_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT char GblVariant_asChar(const GblVariant* pSelf) {
+    char value = '\0';
+    GblVariant_asValue(pSelf, GBL_CHAR_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT uint8_t GblVariant_asUint8(const GblVariant* pSelf) {
+    uint8_t value = 0;
+    GblVariant_asValue(pSelf, GBL_UINT8_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT uint16_t GblVariant_asUint16(const GblVariant* pSelf) {
+    uint16_t value = 0;
+    GblVariant_asValue(pSelf, GBL_UINT16_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT int16_t GblVariant_asInt16(const GblVariant* pSelf) {
+    int16_t value = 0;
+    GblVariant_asValue(pSelf, GBL_INT16_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT uint32_t GblVariant_asUint32(const GblVariant* pSelf) {
+    uint32_t value = 0;
+    GblVariant_asValue(pSelf, GBL_UINT32_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT int32_t GblVariant_asInt32(const GblVariant* pSelf) {
+    int32_t value = 0;
+    GblVariant_asValue(pSelf, GBL_INT32_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT uint64_t GblVariant_asUint64(const GblVariant* pSelf) {
+    uint64_t value = 0;
+    GblVariant_asValue(pSelf, GBL_UINT64_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT int64_t GblVariant_asInt64(const GblVariant* pSelf) {
+    int64_t value = 0;
+    GblVariant_asValue(pSelf, GBL_INT64_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT GblEnum GblVariant_asEnum(const GblVariant* pSelf) {
+    GblEnum value = 0;
+    GblVariant_asValue(pSelf, GBL_ENUM_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT GblFlags GblVariant_asFlags(const GblVariant* pSelf) {
+    GblFlags value = 0;
+    GblVariant_asValue(pSelf, GBL_FLAGS_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT float GblVariant_asFloat(const GblVariant* pSelf) {
+    float value = 0.0f;
+    GblVariant_asValue(pSelf, GBL_FLOAT_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT double GblVariant_asDouble(const GblVariant* pSelf) {
+    double value = 0.0;
+    GblVariant_asValue(pSelf, GBL_DOUBLE_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT void* GblVariant_asPointer(const GblVariant* pSelf) {
+    void* pValue = NULL;
+    GblVariant_asValue(pSelf, GBL_POINTER_TYPE, &pValue);
+    return pValue;
+}
+
+GBL_EXPORT GblStringRef* GblVariant_asString(const GblVariant* pSelf) {
+    GblStringRef* pRef = NULL;
+    GblVariant_asValue(pSelf, GBL_STRING_TYPE, &pRef);
+    return pRef;
+}
+
+GBL_EXPORT size_t GblVariant_asSize(const GblVariant* pSelf) {
+    size_t value = 0;
+    GblVariant_asValue(pSelf, GBL_SIZE_TYPE, &value);
+    return value;
+}
+
+GBL_EXPORT GblDateTime* GblVariant_asDateTime(const GblVariant* pSelf) {
+    GblDateTime *pValue = NULL;
+    GblVariant_asValue(pSelf, GBL_DATE_TIME_TYPE, &pValue);
+    return pValue;
+}
+
 GBL_EXPORT GblBool GblVariant_toBool(GblVariant* pSelf) {
     GblBool value = GBL_FALSE;
     GBL_CTX_BEGIN(NULL);

--- a/test/source/meta/instances/gimbal_object_test_suite.c
+++ b/test/source/meta/instances/gimbal_object_test_suite.c
@@ -363,11 +363,11 @@ GBL_TEST_CASE(propertyGet)
                             //     "stringer", "truckin Inheritance!");
     GBL_TEST_VERIFY(pObj1);
 
-    uint16_t    refCount    = 0;
-    void*       pUserdata   = NULL;
-    const char* pName       = NULL;
-    GblObject*  pParent     = NULL;
-    float       floater     = 0.0f;
+    uint16_t      refCount    = 0;
+    void*         pUserdata   = NULL;
+    GblStringRef* pName       = NULL;
+    GblObject*    pParent     = NULL;
+    float         floater     = 0.0f;
    // const char* pStringer   = NULL;
 
     GBL_RESULT result = GblObject_properties(GBL_OBJECT(pObj1),
@@ -390,6 +390,8 @@ GBL_TEST_CASE(propertyGet)
     GBL_TEST_COMPARE(GBL_UNREF(pObj0),   1);
     GBL_TEST_COMPARE(GBL_UNREF(pObj1),   0);
     GBL_TEST_COMPARE(GBL_UNREF(pParent), 0);
+
+    GblStringRef_unref(pName);
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(propertySet)

--- a/test/source/meta/instances/gimbal_object_test_suite.c
+++ b/test/source/meta/instances/gimbal_object_test_suite.c
@@ -143,7 +143,7 @@ GBL_TEST_CASE(extendedData)
     GblObject* pObj = GBL_OBJECT(GBL_NEW(TestObject));
 
     GBL_TEST_COMPARE(GblObject_name(pObj),           NULL);
-    GBL_TEST_COMPARE(GblBox_userdata(GBL_BOX(pObj)),       NULL);
+    GBL_TEST_COMPARE(GblBox_userdata(GBL_BOX(pObj)), NULL);
     GBL_TEST_COMPARE(GblObject_parent(pObj),         NULL);
     GBL_TEST_COMPARE(GblObject_eventFilterCount(pObj),  0);
 
@@ -154,7 +154,7 @@ GBL_TEST_CASE(extendedData)
     GBL_TEST_COMPARE(GblBox_userdata(GBL_BOX(pObj)), (void*)0xbadbeef);
 
     // make sure we didn't screw up other extended data
-    GBL_TEST_COMPARE(GblObject_parent(pObj),            NULL);
+    GBL_TEST_COMPARE(GblObject_parent(pObj),         NULL);
     GBL_TEST_COMPARE(GblObject_eventFilterCount(pObj),  0);
 
     GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pObj)), 0);
@@ -387,8 +387,9 @@ GBL_TEST_CASE(propertyGet)
     GBL_TEST_COMPARE(floater,        -77.7f);
    // GBL_TEST_COMPARE(pStringer, "truckin Inheritance!");
 
-    GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pObj1)), 0);
-    GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pObj0)), 0);
+    GBL_TEST_COMPARE(GBL_UNREF(pObj0),   1);
+    GBL_TEST_COMPARE(GBL_UNREF(pObj1),   0);
+    GBL_TEST_COMPARE(GBL_UNREF(pParent), 0);
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(propertySet)
@@ -737,10 +738,10 @@ GBL_TEST_CASE(variantITableIndex)
     GblObject* pParent = GblVariant_objectPeek(GblVariant_field(&t, "parent", &v));
     GBL_TEST_VERIFY(pParent);
     GBL_TEST_COMPARE(GblObject_name(pParent), "dynamicParent");
-    //GBL_TEST_COMPARE(GBL_UNREF(pParent), 0);
 
     GBL_TEST_CALL(GblVariant_destruct(&t));
     GBL_TEST_CALL(GblVariant_destruct(&v));
+    GBL_TEST_COMPARE(GBL_UNREF(pParent), 0);
 GBL_TEST_CASE_END
 
 GBL_TEST_CASE(variantITableSetIndex)

--- a/test/source/meta/types/gimbal_variant_test_suite.c
+++ b/test/source/meta/types/gimbal_variant_test_suite.c
@@ -2,6 +2,7 @@
 #include <gimbal/test/gimbal_test_macros.h>
 #include <gimbal/core/gimbal_ctx.h>
 #include <gimbal/meta/types/gimbal_variant.h>
+#include <gimbal/utils/gimbal_date_time.h>
 #include <string.h>
 
 static GBL_RESULT GblVariantTestSuite_checkTypeCompatible_(GblTestSuite* pSelf, GblContext* pCtx) {
@@ -2458,13 +2459,34 @@ static GBL_RESULT GblVariantTestSuite_as_(GblTestSuite* pSuite, GblContext* pCtx
     GBL_CTX_VERIFY_LAST_RECORD();
     GBL_TEST_COMPARE(GblVariant_asUint64(&v),    (uint64_t)7);
     GBL_CTX_VERIFY_LAST_RECORD();
-    GBL_TEST_COMPARE(GblVariant_asFloat(&v),     7.0f);
+    GBL_TEST_COMPARE(GblVariant_asFloat(&v),            7.0f);
     GBL_CTX_VERIFY_LAST_RECORD();
-    GBL_TEST_COMPARE(GblVariant_asDouble(&v),    7.0);
+    GBL_TEST_COMPARE(GblVariant_asDouble(&v),            7.0);
     GBL_CTX_VERIFY_LAST_RECORD();
-    GBL_TEST_COMPARE(GblVariant_asBool(&v),      1);
+    GBL_TEST_COMPARE(GblVariant_asBool(&v),                1);
     GBL_CTX_VERIFY_LAST_RECORD();
-    GBL_TEST_COMPARE(GblVariant_asString(&v),    "7");
+    GBL_TEST_COMPARE(GblVariant_asSize(&v),        (size_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+
+    GblStringRef* pStr = GblVariant_asString(&v);
+    GBL_TEST_COMPARE(pStr, "7");
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GblStringRef_unref(pStr);
+
+    int* pInt = (int*)0xdeadbabe;
+    GBL_CTX_VERIFY_CALL(GblVariant_setPointer(&v, GBL_POINTER_TYPE, pInt));
+    GBL_TEST_COMPARE(GblVariant_asPointer(&v), pInt);
+    GBL_CTX_VERIFY_LAST_RECORD();
+
+    GblDateTime* date = GblDateTime_create(2001, 6, 11);
+    GBL_CTX_VERIFY_CALL(GblVariant_setDateTime(&v, date));
+    GBL_TEST_COMPARE(GblVariant_asDateTime(&v), date);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GblDateTime_unref(date);
+
+    GblEnum testEnum = 1;
+    GBL_CTX_VERIFY_CALL(GblVariant_setEnum(&v, GBL_ENUM_TYPE, testEnum));
+    GBL_TEST_COMPARE(GblVariant_asEnum(&v), testEnum);
     GBL_CTX_VERIFY_LAST_RECORD();
 
     GBL_CTX_VERIFY_CALL(GblVariant_destruct(&v));

--- a/test/source/meta/types/gimbal_variant_test_suite.c
+++ b/test/source/meta/types/gimbal_variant_test_suite.c
@@ -2434,6 +2434,43 @@ static GBL_RESULT GblVariantTestSuite_to_(GblTestSuite* pSuite, GblContext* pCtx
     GBL_CTX_END();
 }
 
+static GBL_RESULT GblVariantTestSuite_as_(GblTestSuite* pSuite, GblContext* pCtx) {
+    GBL_UNUSED(pSuite);
+    GBL_CTX_BEGIN(pCtx);
+
+    GblVariant v;
+    GBL_CTX_VERIFY_CALL(GblVariant_construct(&v, (uint8_t)7));
+    GBL_TEST_COMPARE(GblVariant_asChar(&v),      (char)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asUint8(&v),     (uint8_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asUint16(&v),    (uint16_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asInt16(&v),     (int16_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asUint32(&v),    (uint32_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asInt32(&v),     (int32_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asUint64(&v),    (uint64_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asInt64(&v),     (int64_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asUint64(&v),    (uint64_t)7);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asFloat(&v),     7.0f);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asDouble(&v),    7.0);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asBool(&v),      1);
+    GBL_CTX_VERIFY_LAST_RECORD();
+    GBL_TEST_COMPARE(GblVariant_asString(&v),    "7");
+    GBL_CTX_VERIFY_LAST_RECORD();
+
+    GBL_CTX_VERIFY_CALL(GblVariant_destruct(&v));
+
+    GBL_CTX_END();
+}
 
 GBL_EXPORT GblType GblVariantTestSuite_type(void) {
     static GblType type = GBL_INVALID_TYPE;
@@ -2477,6 +2514,7 @@ GBL_EXPORT GblType GblVariantTestSuite_type(void) {
         { "typeName",               GblVariantTestSuite_typeName_                   },
         { "toInvalid",              GblVariantTestSuite_to_invalid_                 },
         { "to",                     GblVariantTestSuite_to_                         },
+        { "as",                     GblVariantTestSuite_as_                         },
         { NULL,                     NULL                                            }
     };
 


### PR DESCRIPTION
## Summary of Changes

### gimbal_variant
* Added **`GblVariant_asXXXX`** methods for retrieving values in a requested type without modifying the source variant

### gimbal_variant_test_suite
* Added unit tests for the new methods

### gimbal_primitives
* Made **`stringGet_`**'s `COPY` case use `GblStringRef_ref()` instead of `GblStringView_strdup()`

### gimbal_object
* Fixed the **`parent`** property getter using `GblVariant_setValueMove` instead of `GblVariant_setValueCopy`

### gimbal_object_test_suite
* Updated unit tests to reflect the new changes
