### PR TITLE
Add GblObject_findDescendant methods

### DIFF
--- a/lib/api/gimbal/meta/instances/gimbal_object.h
+++ b/lib/api/gimbal/meta/instances/gimbal_object.h
@@ -9,7 +9,7 @@
  *  generic construction, named instances, etc.
  *
  *  \author    2023, 2024, 2025 Falco Girgis
- *  \author                2025 Agustín Bellagamba
+ *  \author                2025, 2026 Agustín Bellagamba
  *  \copyright MIT License
  *
  *  \todo
@@ -73,6 +73,9 @@
 #define GblObject_foreachChildReverse(/*GBL_SELF, name, type=GblObject* */ ...) GblObject_foreachChildReverseDefault_(__VA_ARGS__)
 
 #define GBL_SELF_TYPE GblObject
+
+//! Comparator callback function which gets called with a GblObject and an arbitrary closure, returning 0 if the object matches the desired criteria.
+typedef int (*GblObjectCmpFn)(const GblObject* pObj, void* pClosure);
 
 GBL_DECLS_BEGIN
 
@@ -366,25 +369,31 @@ GBL_EXPORT GblObject* GblObject_siblingPreviousByType   (GBL_CSELF, GblType type
 GBL_EXPORT GblObject* GblObject_siblingPreviousByName   (GBL_CSELF, const char* pName)                          GBL_NOEXCEPT;
 
 //! Returns a pointer to the closest ancestor object of the given object that is of \p ancestorType, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findAncestorByType   (GBL_CSELF, GblType ancestorType) GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findAncestorByType    (GBL_CSELF, GblType ancestorType)                  GBL_NOEXCEPT;
 //! Returns a pointer to the first ancestor found with the given name or NULL if none were found
-GBL_EXPORT GblObject* GblObject_findAncestorByName   (GBL_CSELF, const char* pName)    GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findAncestorByName    (GBL_CSELF, const char* pName)                     GBL_NOEXCEPT;
 //! Returns a pointer to the ancestor object of the given object at the specified \p height, with 1 being the direct parent
-GBL_EXPORT GblObject* GblObject_findAncestorByHeight (GBL_CSELF, size_t height)        GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findAncestorByHeight  (GBL_CSELF, size_t height)                         GBL_NOEXCEPT;
 //! Starting at the root object, returns a pointer to the ancestor of the given object at the specified depth, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findBaseByDepth      (GBL_CSELF, size_t depth)         GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findBaseByDepth       (GBL_CSELF, size_t depth)                          GBL_NOEXCEPT;
 //! Searches through the list of children on the given object, returning a pointer to the first one with the given type, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findChildByType      (GBL_CSELF, GblType childType)    GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findChildByType       (GBL_CSELF, GblType childType)                     GBL_NOEXCEPT;
 //! Searches through the list of children on the given object, returning a pointer to the first one with the given name, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findChildByName      (GBL_CSELF, const char* pName)    GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findChildByName       (GBL_CSELF, const char* pName)                     GBL_NOEXCEPT;
 //! Iterates sequentially over the list of children on the given object, returning a pointer to the one at the given type, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findChildByIndex     (GBL_CSELF, size_t index)         GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findChildByIndex      (GBL_CSELF, size_t index)                          GBL_NOEXCEPT;
 //! Iterates sequentially over the list of siblings to the given object, returning a pointer to the first one of the given type, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findSiblingByType    (GBL_CSELF, GblType siblingType)  GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findSiblingByType     (GBL_CSELF, GblType siblingType)                   GBL_NOEXCEPT;
 //! Iterates sequentially over the list of siblings to the given object, returning a pointer to the first one with the given name, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findSiblingByName    (GBL_CSELF, const char* pName)    GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findSiblingByName     (GBL_CSELF, const char* pName)                     GBL_NOEXCEPT;
 //! Iterates sequentially over the list of siblings to the given object, returning a pointer to the one at the given index, or NULL if there isn't one
-GBL_EXPORT GblObject* GblObject_findSiblingByIndex   (GBL_CSELF, size_t  index)        GBL_NOEXCEPT;
+GBL_EXPORT GblObject* GblObject_findSiblingByIndex    (GBL_CSELF, size_t  index)                         GBL_NOEXCEPT;
+//! Returns a pointer to the closest descendant found that satisfies the provided comparator callback
+GBL_EXPORT GblObject* GblObject_findDescendantByCmpFn (GBL_CSELF, GblObjectCmpFn pCmpFn, void* pClosure) GBL_NOEXCEPT;
+//! Returns a pointer to the closest descendant found that is of \p descendantType, or NULL if there isn't one
+GBL_EXPORT GblObject* GblObject_findDescendantByType  (GBL_CSELF, GblType descendantType)                GBL_NOEXCEPT;
+//! Returns a pointer to the closest descendant found with the given name or NULL if none were found
+GBL_EXPORT GblObject* GblObject_findDescendantByName  (GBL_CSELF, const char* pName)                     GBL_NOEXCEPT;
 //! @}
 
 /*! \name  Event Management

--- a/lib/api/gimbal/meta/instances/gimbal_object.h
+++ b/lib/api/gimbal/meta/instances/gimbal_object.h
@@ -74,8 +74,8 @@
 
 #define GBL_SELF_TYPE GblObject
 
-//! Comparator callback function which gets called with a GblObject and an arbitrary closure, returning 0 if the object matches the desired criteria.
-typedef int (*GblObjectCmpFn)(const GblObject* pObj, void* pClosure);
+//! Comparator callback function which gets called with a GblObject and an arbitrary closure, returning true if the object matches the desired criteria.
+typedef GblBool (*GblObjectCmpFn)(const GblObject* pObj, void* pClosure);
 
 GBL_DECLS_BEGIN
 

--- a/lib/api/gimbal/meta/types/gimbal_variant.h
+++ b/lib/api/gimbal/meta/types/gimbal_variant.h
@@ -36,6 +36,7 @@
  *      - when you have an instance/box/object type, have to propagate inner type to box's outer type
  *
  *  \author     2023 Falco Girgis
+ *  \author     2026 Agustín Bellagamba
  *  \copyright  MIT License
  */
 #ifndef GIMBAL_VARIANT_H

--- a/lib/api/gimbal/preprocessor/gimbal_macro_utils.h
+++ b/lib/api/gimbal/preprocessor/gimbal_macro_utils.h
@@ -4,7 +4,7 @@
  *  \sa gimbal_macro_composition.h, gimbal_macro_sequences.h
  *
  *  \author 2025 Falco Girgis
- *  \author 2025 Agustín Bellagamba
+ *  \author 2025, 2026 Agustín Bellagamba
  *  \copyright MIT License
  */
 

--- a/lib/source/meta/instances/gimbal_object.c
+++ b/lib/source/meta/instances/gimbal_object.c
@@ -15,16 +15,16 @@
 #define GBL_OBJECT_DERIVED_FLAG_INSTANTIATED_MASK_  0x1
 #define GBL_OBJECT_DERIVED_FLAG_CONSTRUCTED_MASK_   0x2
 
-static int GblObject_cmpFn_type_(const GblObject* pObj, void* pClosure) {
+static GblBool GblObject_cmpFn_type_(const GblObject* pObj, void* pClosure) {
     GblType type = (GblType)pClosure;
     if (GblInstance_check(GBL_INSTANCE(pObj), type))
-        return 0;
-    return -1;
+        return GBL_TRUE;
+    return GBL_FALSE;
 }
 
-static int GblObject_cmpFn_Name_(const GblObject* pObj, void* pClosure) {
+static GblBool GblObject_cmpFn_Name_(const GblObject* pObj, void* pClosure) {
     const char* name = (const char*)pClosure;
-    return strcmp(GblObject_name(pObj), name);
+    return strcmp(GblObject_name(pObj), name) == 0;
 }
 
 static GblQuark objectNameQuark_           = GBL_QUARK_INVALID;
@@ -1557,7 +1557,7 @@ GBL_EXPORT GblObject* GblObject_findDescendantByCmpFn(const GblObject* pSelf, Gb
             *(GblObject**)GblArrayList_at(&queue.array, head++);
 
         GblObject_foreachChild(pObject, pChild) {
-            if(!pCmpFn(pChild, pClosure)) {
+            if(pCmpFn(pChild, pClosure)) {
                 GblArrayList_destruct(&queue.array);
                 return pChild;
             }

--- a/lib/source/meta/instances/gimbal_object.c
+++ b/lib/source/meta/instances/gimbal_object.c
@@ -15,6 +15,18 @@
 #define GBL_OBJECT_DERIVED_FLAG_INSTANTIATED_MASK_  0x1
 #define GBL_OBJECT_DERIVED_FLAG_CONSTRUCTED_MASK_   0x2
 
+static int GblObject_cmpFn_type_(const GblObject* pObj, void* pClosure) {
+    GblType type = (GblType)pClosure;
+    if (GblInstance_check(GBL_INSTANCE(pObj), type))
+        return 0;
+    return -1;
+}
+
+static int GblObject_cmpFn_Name_(const GblObject* pObj, void* pClosure) {
+    const char* name = (const char*)pClosure;
+    return strcmp(GblObject_name(pObj), name);
+}
+
 static GblQuark objectNameQuark_           = GBL_QUARK_INVALID;
 static GblQuark objectParentQuark_         = GBL_QUARK_INVALID;
 static GblQuark objectFamilyQuark_         = GBL_QUARK_INVALID;
@@ -1524,6 +1536,48 @@ GBL_EXPORT GblObject* GblObject_findSiblingByIndex(const GblObject* pSelf, size_
     return pAncestor;
 }
 
+GBL_EXPORT GblObject* GblObject_findDescendantByCmpFn(const GblObject* pSelf, GblObjectCmpFn pCmpFn, void* pClosure) {
+    struct {
+        GblArrayList array;
+        GblObject*   stackData[32];
+    } queue;
+
+    GblArrayList_construct(&queue.array,
+                           sizeof(GblObject*),
+                           0,
+                           queue.stackData,
+                           sizeof(queue.stackData));
+
+    GblArrayList_pushBack(&queue.array, &pSelf);
+
+    size_t head = 0;
+
+    while(head < GblArrayList_size(&queue.array)) {
+        GblObject* pObject =
+            *(GblObject**)GblArrayList_at(&queue.array, head++);
+
+        GblObject_foreachChild(pObject, pChild) {
+            if(!pCmpFn(pChild, pClosure)) {
+                GblArrayList_destruct(&queue.array);
+                return pChild;
+            }
+
+            GblArrayList_pushBack(&queue.array, &pChild);
+        }
+    }
+
+    GblArrayList_destruct(&queue.array);
+    return NULL;
+}
+
+GBL_EXPORT GblObject* GblObject_findDescendantByType(const GblObject* pSelf, GblType descendantType) {
+    return GblObject_findDescendantByCmpFn(pSelf, GblObject_cmpFn_type_, (void*)descendantType);
+}
+
+GBL_EXPORT GblObject* GblObject_findDescendantByName(const GblObject* pSelf, const char* pName) {
+    return GblObject_findDescendantByCmpFn(pSelf, GblObject_cmpFn_Name_, (void*)pName);
+}
+
 static GBL_RESULT GblObject_IVariant_construct_(GblVariant* pVariant, size_t  argc, GblVariant* pArgs, GBL_IVARIANT_OP_FLAGS op) {
     GBL_UNUSED(argc);
     GBL_CTX_BEGIN(NULL);
@@ -1775,12 +1829,10 @@ static GBL_RESULT GblObject_property_(const GblObject* pSelf, const GblProperty*
                                 GblBox_userdata(GBL_BOX(pSelf)));
         break;
     case GblObject_Property_Id_children: {
-        GblObject*   pChild    = GblObject_childFirst(pSelf);
         GblRingList* pChildren = GblRingList_createEmpty();
 
-        while (pChild) {
+        GblObject_foreachChild(pSelf, pChild) {
             GblRingList_pushBack(pChildren, pChild);
-            pChild = GblObject_siblingNext(pChild);
         }
 
         GblVariant_setValueMove(pValue,

--- a/test/source/meta/instances/gimbal_object_test_suite.c
+++ b/test/source/meta/instances/gimbal_object_test_suite.c
@@ -1268,6 +1268,44 @@ GBL_TEST_CASE(childLast)
     GBL_UNREF(pParent);
 GBL_TEST_CASE_END
 
+GBL_TEST_CASE(descendantByType)
+    GblObject* pParent               = GBL_NEW(GblObject);
+        GblObject* pChild1           = GBL_NEW(GblObject,  "parent", pParent);
+            GblObject* pDescendant1  = GBL_NEW(GblObject,  "parent", pChild1);
+        GblObject* pChild2           = GBL_NEW(GblObject,  "parent", pParent);
+        GblObject* pChild3           = GBL_NEW(GblObject,  "parent", pParent);
+            TestObject* pDescendant2 = GBL_NEW(TestObject, "parent", pChild3);
+        GblObject* pChild4           = GBL_NEW(GblObject,  "parent", pParent);
+            TestObject* pDescendant3 = GBL_NEW(TestObject, "parent", pChild4);
+
+    GBL_TEST_COMPARE(GblObject_findDescendantByType(pParent, TEST_OBJECT_TYPE), pDescendant2);
+    GBL_TEST_COMPARE(GblObject_findDescendantByType(pParent, GBL_OBJECT_TYPE),  pChild1);
+    GBL_TEST_COMPARE(GblObject_findDescendantByType(pChild1, GBL_OBJECT_TYPE),  pDescendant1);
+    GBL_TEST_COMPARE(GblObject_findDescendantByType(pChild2, GBL_OBJECT_TYPE),  NULL);
+    GBL_TEST_COMPARE(GblObject_findDescendantByType(pParent, GBL_STRING_TYPE),  NULL);
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(descendantByName)
+    GblObject* pParent              = GBL_NEW(GblObject, "name", "Parent");
+        GblObject* pChild1          = GBL_NEW(GblObject, "name", "Child1",      "parent", pParent);
+            GblObject* pDescendant1 = GBL_NEW(GblObject, "name", "Descendant1", "parent", pChild1);
+        GblObject* pChild2          = GBL_NEW(GblObject, "name", "Child2",      "parent", pParent);
+        GblObject* pChild3          = GBL_NEW(GblObject, "name", "Child3",      "parent", pParent);
+            GblObject* pDescendant2 = GBL_NEW(GblObject, "name", "Descendant2", "parent", pChild3);
+        GblObject* pChild4          = GBL_NEW(GblObject, "name", "Child4",      "parent", pParent);
+            GblObject* pDescendant3 = GBL_NEW(GblObject, "name", "Descendant3", "parent", pChild4);
+
+    GBL_TEST_COMPARE(GblObject_findDescendantByName(pParent, "Descendant2"), pDescendant2);
+    GBL_TEST_COMPARE(GblObject_findDescendantByName(pChild1, "Descendant1"), pDescendant1);
+    GBL_TEST_COMPARE(GblObject_findDescendantByName(pChild4, "Descendant3"), pDescendant3);
+    GBL_TEST_COMPARE(GblObject_findDescendantByName(pChild3, "kek"),         NULL);
+    GBL_TEST_COMPARE(GblObject_findDescendantByName(pParent, "mink"),        NULL);
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
 GBL_TEST_REGISTER(newDefault,
                   name,
                   ref,
@@ -1314,7 +1352,9 @@ GBL_TEST_REGISTER(newDefault,
                   clearChildren,
                   setChildren,
                   iterateChildren,
-                  childLast
+                  childLast,
+                  descendantByType,
+                  descendantByName
                 )
 
 static GBL_RESULT TestObject_IEventReceiver_receiveEvent(GblIEventReceiver* pSelf, GblIEventReceiver* pDest, GblEvent* pEvent) {


### PR DESCRIPTION
## Summary of Changes

### `gimbal_object`
* Added the **`GblObjectCmpFn`** type.
* Added **`GblObject_findDescendantByCmpFn`** 
* Added **`GblObject_findDescendantByType`** 
* Added **`GblObject_findDescendantByName`** 
* Updated my author year

### `gimbal_object_test_suite`
* Added unit tests for the new methods

### `gimbal_variant`
* Added myself as an author

### `gimbal_macro_utils`
* Updated my author year
