### PR TITLE
Add new GblObject_XXXXByCmpFn methods, fix GblObject_findSibling methods

### DIFF
--- a/lib/api/gimbal/meta/instances/gimbal_object.h
+++ b/lib/api/gimbal/meta/instances/gimbal_object.h
@@ -357,17 +357,23 @@ GBL_EXPORT size_t     GblObject_childCount              (GBL_CSELF)             
 GBL_EXPORT size_t     GblObject_childIndex              (GBL_CSELF)                                             GBL_NOEXCEPT;
 //! Returns the next sibling after the given object, forming a linked list of their parents' children
 GBL_EXPORT GblObject* GblObject_siblingNext             (GBL_CSELF)                                             GBL_NOEXCEPT;
+//! Returns the next sibling after the given object that satisfies the provided comparator callback, or NULL if there isn't one
+GBL_EXPORT GblObject* GblObject_siblingNextByCmpFn      (GBL_CSELF, GblObjectCmpFn pCmpFn, void* pClosure) GBL_NOEXCEPT;
 //! Returns the next sibling after the given object that is of \p type, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_siblingNextByType       (GBL_CSELF, GblType type)                               GBL_NOEXCEPT;
 //! Returns the next sibling after the given object with the given name, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_siblingNextByName       (GBL_CSELF, const char* pName)                          GBL_NOEXCEPT;
 //! Returns the previous sibling before the given object, forming a linked list of their parents' children
 GBL_EXPORT GblObject* GblObject_siblingPrevious         (GBL_CSELF)                                             GBL_NOEXCEPT;
+//! Returns the previous sibling before the given object that satisfies the provided comparator callback, or NULL if there isn't one
+GBL_EXPORT GblObject* GblObject_siblingPreviousByCmpFn  (GBL_CSELF, GblObjectCmpFn pCmpFn, void* pClosure)      GBL_NOEXCEPT;
 //! Returns the previous sibling before the given object that is of \p type, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_siblingPreviousByType   (GBL_CSELF, GblType type)                               GBL_NOEXCEPT;
 //! Returns the previous sibling before the given object with the given name, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_siblingPreviousByName   (GBL_CSELF, const char* pName)                          GBL_NOEXCEPT;
 
+//! Returns a pointer to the closest ancestor found that satisfies the provided comparator callback, or NULL if there isn't one
+GBL_EXPORT GblObject* GblObject_findAncestorByCmpFn   (GBL_CSELF, GblObjectCmpFn pCmpFn, void* pClosure) GBL_NOEXCEPT;
 //! Returns a pointer to the closest ancestor object of the given object that is of \p ancestorType, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findAncestorByType    (GBL_CSELF, GblType ancestorType)                  GBL_NOEXCEPT;
 //! Returns a pointer to the first ancestor found with the given name or NULL if none were found
@@ -376,19 +382,23 @@ GBL_EXPORT GblObject* GblObject_findAncestorByName    (GBL_CSELF, const char* pN
 GBL_EXPORT GblObject* GblObject_findAncestorByHeight  (GBL_CSELF, size_t height)                         GBL_NOEXCEPT;
 //! Starting at the root object, returns a pointer to the ancestor of the given object at the specified depth, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findBaseByDepth       (GBL_CSELF, size_t depth)                          GBL_NOEXCEPT;
+//! Searches through the list of children on the given object, returning a pointer to the first one that satisfies the provided comparator callback, or NULL if there isn't one
+GBL_EXPORT GblObject* GblObject_findChildByCmpFn      (GBL_CSELF, GblObjectCmpFn pCmpFn, void* pClosure) GBL_NOEXCEPT;
 //! Searches through the list of children on the given object, returning a pointer to the first one with the given type, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findChildByType       (GBL_CSELF, GblType childType)                     GBL_NOEXCEPT;
 //! Searches through the list of children on the given object, returning a pointer to the first one with the given name, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findChildByName       (GBL_CSELF, const char* pName)                     GBL_NOEXCEPT;
 //! Iterates sequentially over the list of children on the given object, returning a pointer to the one at the given type, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findChildByIndex      (GBL_CSELF, size_t index)                          GBL_NOEXCEPT;
+//! Iterates sequentially over the list of siblings to the given object, returning a pointer to the first one that satisfies the provided comparator callback, or NULL if there isn't one
+GBL_EXPORT GblObject* GblObject_findSiblingByCmpFn      (GBL_CSELF, GblObjectCmpFn pCmpFn, void* pClosure) GBL_NOEXCEPT;
 //! Iterates sequentially over the list of siblings to the given object, returning a pointer to the first one of the given type, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findSiblingByType     (GBL_CSELF, GblType siblingType)                   GBL_NOEXCEPT;
 //! Iterates sequentially over the list of siblings to the given object, returning a pointer to the first one with the given name, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findSiblingByName     (GBL_CSELF, const char* pName)                     GBL_NOEXCEPT;
 //! Iterates sequentially over the list of siblings to the given object, returning a pointer to the one at the given index, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findSiblingByIndex    (GBL_CSELF, size_t  index)                         GBL_NOEXCEPT;
-//! Returns a pointer to the closest descendant found that satisfies the provided comparator callback
+//! Returns a pointer to the closest descendant found that satisfies the provided comparator callback, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findDescendantByCmpFn (GBL_CSELF, GblObjectCmpFn pCmpFn, void* pClosure) GBL_NOEXCEPT;
 //! Returns a pointer to the closest descendant found that is of \p descendantType, or NULL if there isn't one
 GBL_EXPORT GblObject* GblObject_findDescendantByType  (GBL_CSELF, GblType descendantType)                GBL_NOEXCEPT;

--- a/lib/source/meta/instances/gimbal_object.c
+++ b/lib/source/meta/instances/gimbal_object.c
@@ -1210,6 +1210,12 @@ GBL_EXPORT GblObject* GblObject_siblingNext(const GblObject* pSelf) {
     return pSibling;
 }
 
+GBL_EXPORT GblObject* GblObject_siblingNextByCmpFn(const GblObject* pSelf, GblObjectCmpFn pCmpFn, void* pClosure) {
+    do pSelf = GblObject_siblingNext(pSelf);
+    while (pSelf != NULL && !pCmpFn(pSelf, pClosure));
+    return pSelf;
+}
+
 GBL_EXPORT GblObject* GblObject_siblingNextByType(const GblObject* pSelf, GblType type) {
     do pSelf = GblObject_siblingNext(pSelf);
     while (pSelf != NULL && GBL_TYPEOF(pSelf) != type);
@@ -1234,6 +1240,12 @@ GBL_EXPORT GblObject* GblObject_siblingPrevious(const GblObject* pSelf) {
     }
 
     return NULL;
+}
+
+GBL_EXPORT GblObject* GblObject_siblingPreviousByCmpFn(const GblObject* pSelf, GblObjectCmpFn pCmpFn, void* pClosure) {
+    do pSelf = GblObject_siblingPrevious(pSelf);
+    while (pSelf != NULL && !pCmpFn(pSelf, pClosure));
+    return pSelf;
 }
 
 GBL_EXPORT GblObject* GblObject_siblingPreviousByType(const GblObject* pSelf, GblType type) {
@@ -1321,6 +1333,16 @@ GBL_EXPORT GblBool GblObject_iterateChildren(const GblObject* pSelf, GblObjectIt
         if (pFnIt(pChild, pUd)) return GBL_TRUE;
 
     return GBL_FALSE;
+}
+
+GBL_EXPORT GblObject* GblObject_findChildByCmpFn(const GblObject* pSelf, GblObjectCmpFn pCmpFn, void* pClosure) {
+    GblObject* pChild = GblObject_childFirst(pSelf);
+    if (!pChild)
+        return NULL;
+
+    if (pCmpFn(pChild, pClosure))
+        return pChild;
+    return GblObject_siblingNextByCmpFn(pChild, pCmpFn, pClosure);
 }
 
 GBL_EXPORT GblObject* GblObject_findChildByType(const GblObject* pSelf, GblType childType) {
@@ -1443,6 +1465,22 @@ GBL_EXPORT GblContext* GblObject_findContext(GblObject* pSelf) {
     return (GblContext*)pContext;
 }
 
+GBL_EXPORT GblObject* GblObject_findAncestorByCmpFn(const GblObject* pSelf, GblObjectCmpFn pCmpFn, void* pClosure) {
+    GblObject* pAncestor = NULL;
+    GblObject* pNode     = GblObject_parent(pSelf);
+
+    while(pNode) {
+        if(pCmpFn(pNode, pClosure)) {
+            pAncestor = pNode;
+            break;
+        }
+
+        pNode = GblObject_parent(pNode);
+    }
+
+    return pAncestor;
+}
+
 GBL_EXPORT GblObject* GblObject_findAncestorByType(const GblObject* pSelf, GblType ancestorType) {
     GblObject* pAncestor = NULL;
     GblObject* pNode = GblObject_parent(pSelf);
@@ -1503,37 +1541,40 @@ GBL_EXPORT GblObject* GblObject_findAncestorBaseByDepth(const GblObject* pSelf, 
     return pBase;
 }
 
+GBL_EXPORT GblObject* GblObject_findSiblingByCmpFn(const GblObject* pSelf, GblObjectCmpFn pCmpFn, void* pClosure) {
+    if(!GblObject_parent(pSelf))
+        return NULL;
+
+    GblObject* pSibling = GblObject_childFirst(GblObject_parent(pSelf));
+    while (pSibling && !pCmpFn(pSibling, pClosure) || pSibling == pSelf)
+        pSibling = GblObject_siblingNextByCmpFn(pSibling, pCmpFn, pClosure);
+    return pSibling;
+}
 
 GBL_EXPORT GblObject* GblObject_findSiblingByType(const GblObject* pSelf, GblType siblingType) {
-    GblObject* pObject = NULL;
+    if(!GblObject_parent(pSelf))
+        return NULL;
 
-    if(GblObject_parent(pSelf)) {
-        GblObject_findChildByType(GblObject_parent(pSelf), siblingType);
-    }
-
-    return pObject;
+    GblObject* pSibling = GblObject_childFirst(GblObject_parent(pSelf));
+    while (pSibling && GBL_TYPEOF(pSibling) != siblingType || pSibling == pSelf)
+        pSibling = GblObject_siblingNextByType(pSibling, siblingType);
+    return pSibling;
 }
 
 GBL_EXPORT GblObject* GblObject_findSiblingByName(const GblObject* pSelf, const char* pName) {
-    GblObject* pObject = NULL;
-    GblObject* pParent = GblObject_parent(pSelf);
+    if(!GblObject_parent(pSelf))
+        return NULL;
 
-    if(pParent) {
-        pObject = GblObject_findChildByName(pParent, pName);
-    }
-
-    return pObject;
+    GblObject* pSibling = GblObject_childFirst(GblObject_parent(pSelf));
+    while (pSibling && strcmp(GblObject_name(pSibling), pName) != 0 || pSibling == pSelf)
+        pSibling = GblObject_siblingNextByName(pSibling, pName);
+    return pSibling;
 }
 
 GBL_EXPORT GblObject* GblObject_findSiblingByIndex(const GblObject* pSelf, size_t  index) {
-    GblObject* pAncestor = NULL;
-    GblObjectFamily_* pFamily = GblObject_family_(pSelf);
-
-    if(pFamily) {
-        pAncestor = GBL_OBJECT_FAMILY_ENTRY_(GblNaryTree_siblingAt(&pFamily->treeNode, index));
-    }
-
-    return pAncestor;
+    if(!GblObject_parent(pSelf) || GblObject_childIndex(pSelf) == index)
+        return NULL;
+    return GblObject_findChildByIndex(GblObject_parent(pSelf), index);
 }
 
 GBL_EXPORT GblObject* GblObject_findDescendantByCmpFn(const GblObject* pSelf, GblObjectCmpFn pCmpFn, void* pClosure) {

--- a/test/source/meta/instances/gimbal_object_test_suite.c
+++ b/test/source/meta/instances/gimbal_object_test_suite.c
@@ -525,6 +525,7 @@ GBL_TEST_CASE(parenting)
     GblObject* pChild3 = GBL_NEW(GblObject, "name", "Child3",
                                             "parent", pChild2);
     GblObject* pParent = GBL_OBJECT(GBL_NEW(TestObject, "name", "Parent"));
+    GblObject* pChild4 = GBL_OBJECT(GBL_NEW(TestObject, "name", "Child4"));
 
     GblObject_setParent(pChild1, pParent);
     GBL_TEST_COMPARE(GblObject_findChildByIndex(pParent, 0), pChild1);
@@ -534,12 +535,20 @@ GBL_TEST_CASE(parenting)
     GBL_TEST_COMPARE(GblObject_parent(pChild2), pParent);
     GBL_TEST_COMPARE(GblObject_siblingNext(pChild1), pChild2);
 
+    GblObject_addChild(pParent, pChild4);
+
     GBL_TEST_COMPARE(GblObject_parent(pChild3), pChild2);
 
     GBL_TEST_COMPARE(GblObject_findAncestorByType(pChild3, TEST_OBJECT_TYPE), pParent);
     GBL_TEST_COMPARE(GblObject_findAncestorByName(pChild2, "Parent"), pParent);
     GBL_TEST_COMPARE(GblObject_findChildByType(pChild2, GBL_OBJECT_TYPE), pChild3);
     GBL_TEST_COMPARE(GblObject_findSiblingByName(pChild1, "Child2"), pChild2);
+    GBL_TEST_COMPARE(GblObject_findSiblingByType(pChild1, TEST_OBJECT_TYPE), pChild4);
+    GBL_TEST_COMPARE(GblObject_findSiblingByType(pChild4, TEST_OBJECT_TYPE), NULL);
+    GBL_TEST_COMPARE(GblObject_findSiblingByIndex(pChild4, 1), pChild2);
+    GBL_TEST_COMPARE(GblObject_findSiblingByIndex(pChild4, 5), NULL);
+    GBL_TEST_COMPARE(GblObject_findSiblingByIndex(pChild3, 1), NULL);
+    GBL_TEST_COMPARE(GblObject_findSiblingByIndex(pChild3, 0), NULL);
     GBL_TEST_COMPARE(GblObject_findChildByName(pParent, "Child1"), pChild1);
 
     GblObject_removeChild(pParent, pChild1);
@@ -551,6 +560,7 @@ GBL_TEST_CASE(parenting)
     GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pChild3)), 0);
     GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pChild1)), 0);
     GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pChild2)), 0);
+    GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pChild4)), 0);
     GBL_TEST_COMPARE(GblBox_unref(GBL_BOX(pParent)), 0);
 GBL_TEST_CASE_END
 
@@ -831,6 +841,31 @@ GBL_TEST_CASE(variantITableNext)
     GblVariant_destruct(&v);
 GBL_TEST_CASE_END
 
+static GblBool GblObject_cmpFn_Name_(const GblObject* pObj, void* pClosure) {
+    const char* name = (const char*)pClosure;
+    return strcmp(GblObject_name(pObj), name) == 0;
+}
+
+GBL_TEST_CASE(siblingNextByCmpFn)
+    GblObject* pParent = GBL_NEW(GblObject);
+    GblObject* pChild1 = GBL_NEW(GblObject, "parent", pParent, "name", "Child1");
+    GblObject* pChild2 = GBL_NEW(GblObject, "parent", pParent, "name", "Child2");
+    GblObject* pChild3 = GBL_NEW(GblObject, "parent", pParent, "name", "Child3");
+    GblObject* pChild4 = GBL_NEW(GblObject, "parent", pParent, "name", "Child4");
+
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Child3"), pChild3);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild2, GblObject_cmpFn_Name_, (void*)"Child3"), pChild3);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild3, GblObject_cmpFn_Name_, (void*)"Child3"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild4, GblObject_cmpFn_Name_, (void*)"Child3"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Child2"), pChild2);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild2, GblObject_cmpFn_Name_, (void*)"Child2"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"mink"),   NULL);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child1"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingNextByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Child4"), pChild4);
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
 GBL_TEST_CASE(siblingNextByType)
     TestObject* pParent = GBL_NEW(TestObject);
     GblObject*  pChild1 = GBL_NEW(GblObject,  "parent", pParent);
@@ -886,6 +921,27 @@ GBL_TEST_CASE(siblingPrevious)
     GBL_TEST_COMPARE(GblObject_siblingPrevious(pChild3), pChild2);
     GBL_TEST_COMPARE(GblObject_siblingPrevious(pChild4), pChild3);
     GBL_TEST_COMPARE(GblObject_siblingPrevious(pParent), NULL);
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(siblingPreviousByCmpFn)
+    GblObject* pParent = GBL_NEW(GblObject);
+    GblObject* pChild1 = GBL_NEW(GblObject, "parent", pParent, "name", "Child1");
+    GblObject* pChild2 = GBL_NEW(GblObject, "parent", pParent, "name", "Child2");
+    GblObject* pChild3 = GBL_NEW(GblObject, "parent", pParent, "name", "Child3");
+    GblObject* pChild4 = GBL_NEW(GblObject, "parent", pParent, "name", "Child4");
+
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Child3"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild2, GblObject_cmpFn_Name_, (void*)"Child3"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild3, GblObject_cmpFn_Name_, (void*)"Child3"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild4, GblObject_cmpFn_Name_, (void*)"Child3"), pChild3);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Child2"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild2, GblObject_cmpFn_Name_, (void*)"Child2"), NULL);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild3, GblObject_cmpFn_Name_, (void*)"Child2"), pChild2);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild4, GblObject_cmpFn_Name_, (void*)"Child2"), pChild2);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pChild4, GblObject_cmpFn_Name_, (void*)"Child1"), pChild1);
+    GBL_TEST_COMPARE(GblObject_siblingPreviousByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child1"), NULL);
 
     GBL_UNREF(pParent);
 GBL_TEST_CASE_END
@@ -1306,6 +1362,63 @@ GBL_TEST_CASE(descendantByName)
     GBL_UNREF(pParent);
 GBL_TEST_CASE_END
 
+GBL_TEST_CASE(findAncestorByCmpFn)
+    GblObject* pParent              = GBL_NEW(GblObject, "name", "Parent");
+        GblObject* pChild1          = GBL_NEW(GblObject, "name", "Child1",      "parent", pParent);
+            GblObject* pDescendant1 = GBL_NEW(GblObject, "name", "Descendant1", "parent", pChild1);
+        GblObject* pChild2          = GBL_NEW(GblObject, "name", "Child2",      "parent", pParent);
+
+    GBL_TEST_COMPARE(GblObject_findAncestorByCmpFn(pDescendant1, GblObject_cmpFn_Name_, (void*)"Parent"),  pParent);
+    GBL_TEST_COMPARE(GblObject_findAncestorByCmpFn(pDescendant1, GblObject_cmpFn_Name_, (void*)"Child1"),  pChild1);
+    GBL_TEST_COMPARE(GblObject_findAncestorByCmpFn(pChild1,      GblObject_cmpFn_Name_, (void*)"Parent"),  pParent);
+    GBL_TEST_COMPARE(GblObject_findAncestorByCmpFn(pDescendant1, GblObject_cmpFn_Name_, (void*)"haikuno"), NULL);
+    GBL_TEST_COMPARE(GblObject_findAncestorByCmpFn(pParent,      GblObject_cmpFn_Name_, (void*)"Parent"),  NULL);
+
+    GBL_UNREF(pParent);
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(findChildByCmpFn)
+    GblObject* pParent = GBL_NEW(GblObject);
+    GblObject* pChild1 = GBL_NEW(GblObject, "parent", pParent, "name", "Child1");
+    GblObject* pChild2 = GBL_NEW(GblObject, "parent", pParent, "name", "Child2");
+    GblObject* pChild3 = GBL_NEW(GblObject, "parent", pParent, "name", "Child3");
+    GblObject* pChild4 = GBL_NEW(GblObject, "parent", pParent, "name", "Child4");
+    GblObject* pDummy  = GBL_NEW(GblObject,                    "name", "Dummy" );
+
+    GBL_TEST_COMPARE(GblObject_findChildByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child1"), pChild1);
+    GBL_TEST_COMPARE(GblObject_findChildByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child2"), pChild2);
+    GBL_TEST_COMPARE(GblObject_findChildByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child3"), pChild3);
+    GBL_TEST_COMPARE(GblObject_findChildByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child4"), pChild4);
+    GBL_TEST_COMPARE(GblObject_findChildByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child5"), NULL   );
+    GBL_TEST_COMPARE(GblObject_findChildByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Dummy"),  NULL   );
+    GBL_TEST_COMPARE(GblObject_findChildByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Mink"),   NULL   );
+
+    GBL_UNREF(pParent);
+    GBL_UNREF(pDummy );
+GBL_TEST_CASE_END
+
+GBL_TEST_CASE(findSiblingByCmpFn)
+    GblObject* pParent = GBL_NEW(GblObject);
+    GblObject* pChild1 = GBL_NEW(GblObject, "parent", pParent, "name", "Child1");
+    GblObject* pChild2 = GBL_NEW(GblObject, "parent", pParent, "name", "Child2");
+    GblObject* pChild3 = GBL_NEW(GblObject, "parent", pParent, "name", "Child3");
+    GblObject* pChild4 = GBL_NEW(GblObject, "parent", pParent, "name", "Child4");
+    GblObject* pDummy  = GBL_NEW(GblObject,                    "name", "Dummy" );
+
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pParent, GblObject_cmpFn_Name_, (void*)"Child1"), NULL);
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pDummy , GblObject_cmpFn_Name_, (void*)"Mink"),   NULL);
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Child2"), pChild2);
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pChild2, GblObject_cmpFn_Name_, (void*)"Child2"), NULL);
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pChild3, GblObject_cmpFn_Name_, (void*)"Child4"), pChild4);
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pChild4, GblObject_cmpFn_Name_, (void*)"Child5"), NULL   );
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pChild4, GblObject_cmpFn_Name_, (void*)"Child2"), pChild2);
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pChild4, GblObject_cmpFn_Name_, (void*)"Child1"), pChild1);
+    GBL_TEST_COMPARE(GblObject_findSiblingByCmpFn(pChild1, GblObject_cmpFn_Name_, (void*)"Dummy"),  NULL   );
+
+    GBL_UNREF(pParent);
+    GBL_UNREF(pDummy );
+GBL_TEST_CASE_END
+
 GBL_TEST_REGISTER(newDefault,
                   name,
                   ref,
@@ -1333,9 +1446,11 @@ GBL_TEST_REGISTER(newDefault,
                   variantITableIndex,
                   variantITableSetIndex,
                   variantITableNext,
+                  siblingNextByCmpFn,
                   siblingNextByType,
                   siblingNextByName,
                   siblingPrevious,
+                  siblingPreviousByCmpFn,
                   siblingPreviousByType,
                   siblingPreviousByName,
                   childIndex,
@@ -1354,7 +1469,10 @@ GBL_TEST_REGISTER(newDefault,
                   iterateChildren,
                   childLast,
                   descendantByType,
-                  descendantByName
+                  descendantByName,
+                  findAncestorByCmpFn,
+                  findChildByCmpFn,
+                  findSiblingByCmpFn
                 )
 
 static GBL_RESULT TestObject_IEventReceiver_receiveEvent(GblIEventReceiver* pSelf, GblIEventReceiver* pDest, GblEvent* pEvent) {


### PR DESCRIPTION
## Summary of Changes

### `gimbal_object`
* Added **`GblObject_siblingNextByCmpFn`** 
* Added **`GblObject_siblingPreviousByCmpFn`**
* Added **`GblObject_findAncestorByCmpFn`**
* Added **`GblObject_findChildByCmpFn`**
* Added **`GblObject_findSiblingByCmpFn`**
* Fix **`GblObject_findSiblingByType`** always returning **`NULL`**
* Fix **`GblObject_findSiblingByName`** being able to return **`pSelf`**
* Fix **`GblObject_findSiblingByIndex`** being able to return **`pSelf`**

### `gimbal_object_test_suite`
* Added unit tests for the new methods
* Modified the **`parenting`** unit test to reflect the fixes