### PR TITLE
Add DSL macros for GblEnum and GblFlags

### DIFF
--- a/lib/api/gimbal/meta/classes/gimbal_enum.h
+++ b/lib/api/gimbal/meta/classes/gimbal_enum.h
@@ -3,7 +3,6 @@
  *  \ingroup meta
  *
  *  \todo
- *  - Macro DSL for auto registering and declaring enum at the same time
  *  - Finish docs (method descriptions)
  *
  *  \author 2023 Falco Girgis
@@ -32,6 +31,14 @@
 //! @}
 
 #define GBL_SELF_TYPE GblEnumClass
+
+/*! \brief DSL macro used to declare and register a GblEnum
+ *
+ *  \param name Name of the GblEnum
+ *  \param ...  Enum entries in the form:
+ *              (value, nick, number)
+ */
+#define GBL_ENUM(name, ...)  GBL_ENUM_(name, __VA_ARGS__)
 
 GBL_DECLS_BEGIN
 
@@ -121,18 +128,38 @@ GBL_EXPORT GblBool     GblEnum_check     (GblEnum value, GblType type) GBL_NOEXC
 
 GBL_DECLS_END
 
-#if 0
-#define GBL_ENUM(name, ...)     GBL_ENUM_(name, __VA_ARGS__)
+//! \cond GRUG_FREE
 
-#define GBL_ENUM_ENTRY_(name, ...) \
-    GBL_ENUM_ENTRY(__VA_ARGS__)
+#define GBL_ENUM_(name, ...)                                    \
+    GBL_DECLARE_ENUM(name) {                                    \
+        GBL_TUPLE_FOREACH(GBL_ENUM_DECL_, name, (__VA_ARGS__))  \
+    };                                                          \
+    GBL_ENUM_REGISTER_(name, __VA_ARGS__)
 
-#define GBL_ENUM_(name, ...) \
-    GBL_DECLARE_ENUM(name) { \
-        GBL_TUPLE_FOREACH(GBL_ENUM_ENTRY_, name, __VA_ARGS__) \
-        GBL_ENUM_ENTRY_LAST()
-    };
-#endif
+#define GBL_ENUM_REGISTER_(name, ...)                                   \
+    GBL_INLINE GblType name##_type(void) GBL_NOEXCEPT {                 \
+        static GblType type_ = GBL_INVALID_TYPE;                        \
+        if(type_ == GBL_INVALID_TYPE) {                                 \
+            static const GblEnumEntry entries_[] = {                    \
+                GBL_TUPLE_FOREACH(GBL_ENUM_TABLE_, name, (__VA_ARGS__)) \
+                GBL_ENUM_ENTRY_LAST()                                   \
+            };                                                          \
+            type_ = GblEnum_register(GBL_STRINGIFY(name), entries_);    \
+        }                                                               \
+        return type_;                                                   \
+    }
+
+#define GBL_ENUM_DECL_(name, entry)  GBL_ENUM_DECL__(GBL_EVAL entry)
+#define GBL_ENUM_DECL__(...)         GBL_ENUM_DECL___(__VA_ARGS__)
+#define GBL_ENUM_DECL___(value, nick, num) \
+    value = num,
+
+#define GBL_ENUM_TABLE_(name, entry)  GBL_ENUM_TABLE__(GBL_EVAL entry)
+#define GBL_ENUM_TABLE__(...)         GBL_ENUM_TABLE___(__VA_ARGS__)
+#define GBL_ENUM_TABLE___(value, nick, num) \
+    GBL_ENUM_ENTRY(value, nick),
+
+//! \endcond
 
 #undef GBL_SELF_TYPE
 

--- a/lib/api/gimbal/meta/classes/gimbal_enum.h
+++ b/lib/api/gimbal/meta/classes/gimbal_enum.h
@@ -136,17 +136,20 @@ GBL_DECLS_END
     };                                                          \
     GBL_ENUM_REGISTER_(name, __VA_ARGS__)
 
-#define GBL_ENUM_REGISTER_(name, ...)                                   \
-    GBL_INLINE GblType name##_type(void) GBL_NOEXCEPT {                 \
-        static GblType type_ = GBL_INVALID_TYPE;                        \
-        if(type_ == GBL_INVALID_TYPE) {                                 \
-            static const GblEnumEntry entries_[] = {                    \
-                GBL_TUPLE_FOREACH(GBL_ENUM_TABLE_, name, (__VA_ARGS__)) \
-                GBL_ENUM_ENTRY_LAST()                                   \
-            };                                                          \
-            type_ = GblEnum_register(GBL_STRINGIFY(name), entries_);    \
-        }                                                               \
-        return type_;                                                   \
+#define GBL_ENUM_REGISTER_(name, ...)                                       \
+    GBL_INLINE GblType name##_type(void) GBL_NOEXCEPT {                     \
+        static GblType type_ = GBL_INVALID_TYPE;                            \
+        if(type_ == GBL_INVALID_TYPE) {                                     \
+            type_ = GblType_find(GBL_STRINGIFY(name));                      \
+            if (type_ == GBL_INVALID_TYPE) {                                \
+                static const GblEnumEntry entries_[] = {                    \
+                    GBL_TUPLE_FOREACH(GBL_ENUM_TABLE_, name, (__VA_ARGS__)) \
+                    GBL_ENUM_ENTRY_LAST()                                   \
+                };                                                          \
+                type_ = GblEnum_register(GBL_STRINGIFY(name), entries_);    \
+            }                                                               \
+        }                                                                   \
+        return type_;                                                       \
     }
 
 #define GBL_ENUM_DECL_(name, entry)  GBL_ENUM_DECL__(GBL_EVAL entry)

--- a/lib/api/gimbal/meta/classes/gimbal_enum.h
+++ b/lib/api/gimbal/meta/classes/gimbal_enum.h
@@ -6,6 +6,7 @@
  *  - Finish docs (method descriptions)
  *
  *  \author 2023 Falco Girgis
+ *  \author 2026 Agustín Bellagamba
  *  \copyright MIT License
  */
 #ifndef GIMBAL_ENUM_H

--- a/lib/api/gimbal/meta/classes/gimbal_flags.h
+++ b/lib/api/gimbal/meta/classes/gimbal_flags.h
@@ -3,6 +3,7 @@
  *  \ingroup meta
  *
  *  \author 2023 Falco Girgis
+ *  \author 2026 Agustín Bellagamba
  *  \copyright MIT License
  */
 #ifndef GIMBAL_FLAGS_H

--- a/lib/api/gimbal/meta/classes/gimbal_flags.h
+++ b/lib/api/gimbal/meta/classes/gimbal_flags.h
@@ -142,17 +142,20 @@ GBL_DECLS_END
     };                                                          \
     GBL_FLAGS_REGISTER_(name, __VA_ARGS__)
 
-#define GBL_FLAGS_REGISTER_(name, ...)                                   \
-    GBL_INLINE GblType name##_type(void) GBL_NOEXCEPT {                  \
-        static GblType type_ = GBL_INVALID_TYPE;                         \
-        if(type_ == GBL_INVALID_TYPE) {                                  \
-            static const GblFlagEntry entries_[] = {                     \
-                GBL_TUPLE_FOREACH(GBL_FLAGS_TABLE_, name, (__VA_ARGS__)) \
-                GBL_FLAGS_ENTRY_LAST()                                   \
-            };                                                           \
-            type_ = GblFlags_register(GBL_STRINGIFY(name), entries_);    \
-        }                                                                \
-        return type_;                                                    \
+#define GBL_FLAGS_REGISTER_(name, ...)                                       \
+    GBL_INLINE GblType name##_type(void) GBL_NOEXCEPT {                      \
+        static GblType type_ = GBL_INVALID_TYPE;                             \
+        if(type_ == GBL_INVALID_TYPE) {                                      \
+            type_ = GblType_find(GBL_STRINGIFY(name));                       \
+            if(type_ == GBL_INVALID_TYPE) {                                  \
+                static const GblFlagEntry entries_[] = {                     \
+                    GBL_TUPLE_FOREACH(GBL_FLAGS_TABLE_, name, (__VA_ARGS__)) \
+                    GBL_FLAGS_ENTRY_LAST()                                   \
+                };                                                           \
+                type_ = GblFlags_register(GBL_STRINGIFY(name), entries_);    \
+            }                                                                \
+        }                                                                    \
+        return type_;                                                        \
     }
 
 #define GBL_FLAGS_DECL_(name, entry)  GBL_FLAGS_DECL__(GBL_EVAL entry)

--- a/lib/api/gimbal/meta/classes/gimbal_flags.h
+++ b/lib/api/gimbal/meta/classes/gimbal_flags.h
@@ -29,13 +29,21 @@
 
 #define GBL_SELF_TYPE GblFlagsClass
 
+/*! \brief DSL macro used to declare and register GblFlags
+ *
+ *  \param name Name of the GblFlags
+ *  \param ...  Flag entries in the form:
+ *              (value, nick, number)
+ */
+#define GBL_FLAGS(name, ...)  GBL_FLAGS_(name, __VA_ARGS__)
+
 GBL_DECLS_BEGIN
 
 //! Attributes for a single bit flag value within a group of GblFlag values
 typedef struct GblFlagEntry {
     GblFlags        value;  //!< Value of the flag
     const char*     pName;  //!< String name of the flag value
-    const char*     pNick;  //!< Alternat ename of the flag value
+    const char*     pNick;  //!< Alternate name of the flag value
 } GblFlagEntry;
 
 /*! \struct GblFlagsClass
@@ -125,6 +133,39 @@ GBL_EXPORT GBL_RESULT  GblFlags_appendString            (GblFlags value,
                                                          GblStringBuffer* pBuffer)        GBL_NOEXCEPT;
 
 GBL_DECLS_END
+
+//! \cond GRUG_FREE
+
+#define GBL_FLAGS_(name, ...)                                   \
+    GBL_DECLARE_FLAGS(name) {                                   \
+        GBL_TUPLE_FOREACH(GBL_FLAGS_DECL_, name, (__VA_ARGS__)) \
+    };                                                          \
+    GBL_FLAGS_REGISTER_(name, __VA_ARGS__)
+
+#define GBL_FLAGS_REGISTER_(name, ...)                                   \
+    GBL_INLINE GblType name##_type(void) GBL_NOEXCEPT {                  \
+        static GblType type_ = GBL_INVALID_TYPE;                         \
+        if(type_ == GBL_INVALID_TYPE) {                                  \
+            static const GblFlagEntry entries_[] = {                     \
+                GBL_TUPLE_FOREACH(GBL_FLAGS_TABLE_, name, (__VA_ARGS__)) \
+                GBL_FLAGS_ENTRY_LAST()                                   \
+            };                                                           \
+            type_ = GblFlags_register(GBL_STRINGIFY(name), entries_);    \
+        }                                                                \
+        return type_;                                                    \
+    }
+
+#define GBL_FLAGS_DECL_(name, entry)  GBL_FLAGS_DECL__(GBL_EVAL entry)
+#define GBL_FLAGS_DECL__(...)         GBL_FLAGS_DECL___(__VA_ARGS__)
+#define GBL_FLAGS_DECL___(value, nick, num) \
+    value = num,
+
+#define GBL_FLAGS_TABLE_(name, entry)  GBL_FLAGS_TABLE__(GBL_EVAL entry)
+#define GBL_FLAGS_TABLE__(...)         GBL_FLAGS_TABLE___(__VA_ARGS__)
+#define GBL_FLAGS_TABLE___(value, nick, num) \
+    GBL_FLAGS_ENTRY(value, nick),
+
+//! \endcond
 
 #undef GBL_SELF_TYPE
 

--- a/test/source/meta/classes/gimbal_enum_test_suite.c
+++ b/test/source/meta/classes/gimbal_enum_test_suite.c
@@ -36,7 +36,7 @@ static GBL_RESULT GblEnumTestSuite_register_(GblTestSuite* pSelf, GblContext* pC
     GBL_CTX_BEGIN(pCtx);
     GblEnumTestSuite_* pSelf_ = GBL_ENUM_TEST_SUITE_(pSelf);
 
-    pSelf_->enumType = COLOR_type();
+    pSelf_->enumType = GBL_TYPEID(COLOR);
     GBL_CTX_VERIFY_LAST_RECORD();
 
     GBL_TEST_VERIFY(pSelf_->enumType != GBL_INVALID_TYPE);

--- a/test/source/meta/classes/gimbal_enum_test_suite.c
+++ b/test/source/meta/classes/gimbal_enum_test_suite.c
@@ -11,11 +11,11 @@ typedef struct GblEnumTestSuite_ {
     GblEnumClass*   pEnumClass;
 } GblEnumTestSuite_;
 
-typedef enum COLOR {
-    RED     = 1,
-    GREEN   = 5,
-    BLUE    = 10
-} COLOR;
+GBL_ENUM(COLOR,
+    (RED,   "Red",    1),
+    (GREEN, "Green",  5),
+    (BLUE,  "Blue",  10)
+)
 
 static GBL_RESULT GblEnumTestSuite_init_(GblTestSuite* pSelf, GblContext* pCtx) {
     GBL_CTX_BEGIN(pCtx);
@@ -36,15 +36,7 @@ static GBL_RESULT GblEnumTestSuite_register_(GblTestSuite* pSelf, GblContext* pC
     GBL_CTX_BEGIN(pCtx);
     GblEnumTestSuite_* pSelf_ = GBL_ENUM_TEST_SUITE_(pSelf);
 
-    const static GblEnumEntry enumEntries[] = {
-        GBL_ENUM_ENTRY(RED,    "Red"),
-        GBL_ENUM_ENTRY(GREEN,  "Green"),
-        GBL_ENUM_ENTRY(BLUE,   "Blue"),
-        GBL_ENUM_ENTRY_LAST()
-    };
-
-    pSelf_->enumType = GblEnum_register("Color",
-                                enumEntries);
+    pSelf_->enumType = COLOR_type();
     GBL_CTX_VERIFY_LAST_RECORD();
 
     GBL_TEST_VERIFY(pSelf_->enumType != GBL_INVALID_TYPE);

--- a/test/source/meta/classes/gimbal_flags_test_suite.c
+++ b/test/source/meta/classes/gimbal_flags_test_suite.c
@@ -38,7 +38,7 @@ static GBL_RESULT GblFlagsTestSuite_final_(GblTestSuite* pSelf, GblContext* pCtx
 static GBL_RESULT GblFlagsTestSuite_register_(GblTestSuite* pSelf, GblContext* pCtx) {
     GBL_CTX_BEGIN(pCtx);
     GblFlagsTestSuite_* pSelf_ = GBL_FLAGS_TEST_SUITE_(pSelf);
-    pSelf_->flagsType = PROPERTY_FLAGS_type();
+    pSelf_->flagsType = GBL_TYPEID(PROPERTY_FLAGS);
     GBL_CTX_VERIFY_LAST_RECORD();
 
     GBL_TEST_VERIFY(pSelf_->flagsType != GBL_INVALID_TYPE);

--- a/test/source/meta/classes/gimbal_flags_test_suite.c
+++ b/test/source/meta/classes/gimbal_flags_test_suite.c
@@ -13,12 +13,12 @@ typedef struct GblFlagsTestSuite_ {
     GblFlagsClass*  pFlagsClass;
 } GblFlagsTestSuite_;
 
-GBL_DECLARE_FLAGS(PROPERTY_FLAGS) {
-    READ    = 0x1,
-    WRITE   = 0x2,
-    LOAD    = 0x4,
-    SAVE    = 0x8
-};
+GBL_FLAGS(PROPERTY_FLAGS,
+    (READ,  "Read",  0x1),
+    (WRITE, "Write", 0x2),
+    (LOAD,  "Load",  0x4),
+    (SAVE,  "Save",  0x8)
+)
 
 static GBL_RESULT GblFlagsTestSuite_init_(GblTestSuite* pSelf, GblContext* pCtx) {
     GBL_CTX_BEGIN(pCtx);
@@ -38,14 +38,7 @@ static GBL_RESULT GblFlagsTestSuite_final_(GblTestSuite* pSelf, GblContext* pCtx
 static GBL_RESULT GblFlagsTestSuite_register_(GblTestSuite* pSelf, GblContext* pCtx) {
     GBL_CTX_BEGIN(pCtx);
     GblFlagsTestSuite_* pSelf_ = GBL_FLAGS_TEST_SUITE_(pSelf);
-    pSelf_->flagsType = GblFlags_register("PropertyFlags",
-                                   (const GblFlagEntry[]){
-                                       GBL_FLAGS_ENTRY(READ,    "Read"),
-                                       GBL_FLAGS_ENTRY(WRITE,   "Write"),
-                                       GBL_FLAGS_ENTRY(LOAD,    "Load"),
-                                       GBL_FLAGS_ENTRY(SAVE,    "Save"),
-                                       GBL_FLAGS_ENTRY_LAST()
-                                   });
+    pSelf_->flagsType = PROPERTY_FLAGS_type();
     GBL_CTX_VERIFY_LAST_RECORD();
 
     GBL_TEST_VERIFY(pSelf_->flagsType != GBL_INVALID_TYPE);


### PR DESCRIPTION
## Summary of Changes

### `gimbal_enum`
* Added the **`GBL_ENUM()`** DSL macro for declaring and registering a `GblEnum`

### `gimbal_enum_test_suite`
* Modified the test suite to use the new macro

### `gimbal_flags`
* Added the **`GBL_FLAGS()`** DSL macro for declaring and registering `GblFlags`

### `gimbal_flags_test_suite`
* Modified the test suite to use the new macro