### PR TITLE
Remove GblOpaque's duplicated variant converter registration

### DIFF
--- a/lib/source/meta/classes/gimbal_opaque.c
+++ b/lib/source/meta/classes/gimbal_opaque.c
@@ -240,10 +240,6 @@ GBL_EXPORT GblType GblOpaque_register(const char*            pName,
                             GBL_TYPE_FLAGS_NONE);
     GBL_CTX_VERIFY_LAST_RECORD();
 
-    GBL_CTX_CALL(GblVariant_registerConverter(GBL_NIL_TYPE, type, GblOpaque_convertFrom_));
-    GBL_CTX_CALL(GblVariant_registerConverter(GBL_POINTER_TYPE, type, GblOpaque_convertFrom_));
-
-
     GBL_CTX_END_BLOCK();
     return type;
 }


### PR DESCRIPTION
While working on the gimbal tests PR, I noticed that flipping the order of the `GblOpaque` and `GblPointer` test suites caused the tests to fail. 

If you ran the `GblOpaque` tests first, it wouldn't work

So, after some testing, I discovered this reest: 

```c
GBL_EXPORT GblType GblOpaque_type(void) {
       ( ... )

        GBL_CTX_CALL(GblVariant_registerConverter(type, GBL_BOOL_TYPE,    GblOpaque_convertTo_));
        GBL_CTX_CALL(GblVariant_registerConverter(type, GBL_STRING_TYPE,  GblOpaque_convertTo_));
        GBL_CTX_CALL(GblVariant_registerConverter(type, GBL_POINTER_TYPE, GblOpaque_convertTo_));

        GBL_CTX_CALL(GblVariant_registerConverter(GBL_NIL_TYPE,     type, GblOpaque_convertFrom_));
        GBL_CTX_CALL(GblVariant_registerConverter(GBL_POINTER_TYPE, type, GblOpaque_convertFrom_));

        GBL_CTX_END_BLOCK();

    }
    return type;
}

GBL_EXPORT GblType GblOpaque_register(const char*            pName,
                                      const GblOpaqueVTable* pVTable)
{
   ( ... )
    type = GblType_register(...);
    
    // These should not be here, since this function already calls `GblOpaque_type()`
    GBL_CTX_CALL(GblVariant_registerConverter(GBL_NIL_TYPE, type, GblOpaque_convertFrom_)); 
    GBL_CTX_CALL(GblVariant_registerConverter(GBL_POINTER_TYPE, type, GblOpaque_convertFrom_));


    GBL_CTX_END_BLOCK();
    return type;
}
```

All tests now pass and I can sort them alphabetically so my ADHD ass is happy :mink: