### PR TITLE
Fix out-of-bounds access in gblSortComb() when count is 0

### DIFF
--- a/lib/source/algorithms/gimbal_sort.c
+++ b/lib/source/algorithms/gimbal_sort.c
@@ -119,6 +119,8 @@ GBL_EXPORT void gblSortBubble(void* pArray, size_t  count, size_t  elemSize, Gbl
 }
 
 GBL_EXPORT void gblSortComb(void* pArray, size_t count, size_t elemSize, GblSortComparatorFn pFnCmp) {
+    if(count <= 1) return;
+
     // Initialize gap
     int gap = count;
 


### PR DESCRIPTION
## Problem

`gblSortComb()` assigns the `size_t count` parameter into a signed `int gap`:

```c
int gap = count;
```

and then uses it in the inner loop bound:

```c
for (int i = 0; i < count - gap; ++i)
```

When `count == 0`, `gap` becomes `0` after the first gap-shrink step (`gap = (gap * 10) / 13`, clamped to `1` only when it would go below `1`... actually on the very first iteration `gap` starts at `0`, `(0*10)/13 == 0`, clamped to `1`). The loop bound `count - gap` is then evaluated as unsigned `size_t` arithmetic (`0 - 1`), underflowing to `SIZE_MAX`. The `for` loop then iterates with `i` running from `0` up toward `SIZE_MAX`, reading and writing far outside the (zero-sized) array via `GBL_PTR_OFFSET(pArray, i * elemSize)`, causing an out-of-bounds access.

`gblSortMerge()`, right above it in the same file, already guards against this exact case:

```c
if(count <= 1) return;
```

`gblSortComb()` lacked the equivalent guard, even though `gimbal_sort.h` documents no lower bound on `count` for any of the sort functions, and `count == 0` (or `1`, already trivially sorted) is a legitimate, expected input.

## Verification

I reproduced this with a standalone harness that copies `gblSortComb()`'s body verbatim (with the library's real `GBL_ALLOCA`/`GBL_PTR_OFFSET`/`GblBool` macros), placing the array pointer at a `VirtualAlloc`+`VirtualProtect(PAGE_NOACCESS)` guard-page boundary to represent the zero bytes backing a `count == 0` call:

- Unfixed code: `gblSortComb(pArray, 0, sizeof(int), cmp)` crashes immediately with a genuine access violation.
- With the one-line guard added: the identical call completes safely without touching the guard page.
- A separate functional-regression harness confirmed byte-identical, correctly-sorted output for `count = 1, 9, 512` with and without the fix — no behavioral change for legitimate inputs.

## Fix

Add the same early-return guard used by `gblSortMerge()`, mirroring existing style/convention in this file:

```c
GBL_EXPORT void gblSortComb(void* pArray, size_t count, size_t elemSize, GblSortComparatorFn pFnCmp) {
    if(count <= 1) return;

    // Initialize gap
    int gap = count;
    ...
```